### PR TITLE
Added code which captures how to start agent

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,0 +1,8 @@
+export interface Config {
+  service?: string;
+  serviceVersion?: string;
+  projectId?: string;
+  instance?: string;
+  zone?: string;
+  apiAddr?: string;  
+}

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,27 @@
+'use strict'
+
+import { Config } from './config'
+
+/**
+* Start the profiling agent
+* Currently unimplemented
+*
+* @param {object=} config - Profiler configuration
+*
+* @example
+* profiler.start();
+*/
+function start(projectConfig: Config) {
+  console.log("UNIMPLEMENTED");
+}
+
+module.exports = {
+  start: start 
+};
+
+// If the module was --require'd from the command line, start the agent
+if (module.parent && module.parent.id === 'internal/preload') {
+  module.exports.start();
+}
+
+export default {};

--- a/index_test.js
+++ b/index_test.js
@@ -1,0 +1,4 @@
+var profiler = require('./index');
+
+profiler.start({});
+

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "protobufjs": "~5.0.1"
   },
   "devDependencies": {
+    "@types/node": "^8.0.30",
     "clang-format": "^1.0.33"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "lib": [ "es6" ],
+    "declaration": true,
+    "strict": true
+  }
+}


### PR DESCRIPTION
Code here generally captures how the interface for starting the profiling agent should work.

Generally, one should be able to start the profiler by either including, then starting the profiler
`
var profiler = require('./index');
profiler.start(config); // where config implements Config interface
`

or by requiring the profiler at runtime
`node --require ./index some_program.js`
