### PR TITLE
chore: generate js/d.ts from profiler.proto

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "prepare": "npm run compile",
     "pretest": "npm run compile",
     "posttest": "npm run check",
-    "proto:profile": "mkdir -p proto && pbjs -t static-module -w commonjs -o proto/profile.js third_party/proto/profile.proto && pbts -o proto/profile.d.ts proto/profile.js"
+    "proto": "npm run proto:profile && npm run proto:profiler",
+    "proto:profile": "mkdir -p proto && pbjs -t static-module -w commonjs -o proto/profile.js third_party/proto/profile.proto && pbts -o proto/profile.d.ts proto/profile.js",
+    "proto:profiler": "mkdir -p proto && pbjs -t static-module -w commonjs -o proto/profiler.js third_party/googleapis/google/devtools/cloudprofiler/v2/profiler.proto && pbts -o proto/profiler.d.ts proto/profiler.js"
   },
   "author": {
     "name": "Google Inc."

--- a/proto/profiler.d.ts
+++ b/proto/profiler.d.ts
@@ -1,0 +1,3874 @@
+import * as $protobuf from "protobufjs";
+
+/** Namespace google. */
+export namespace google {
+
+    /** Namespace devtools. */
+    namespace devtools {
+
+        /** Namespace cloudprofiler. */
+        namespace cloudprofiler {
+
+            /** Namespace v2. */
+            namespace v2 {
+
+                /** Represents a ProfilerService */
+                class ProfilerService extends $protobuf.rpc.Service {
+
+                    /**
+                     * Constructs a new ProfilerService service.
+                     * @param rpcImpl RPC implementation
+                     * @param [requestDelimited=false] Whether requests are length-delimited
+                     * @param [responseDelimited=false] Whether responses are length-delimited
+                     */
+                    constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);
+
+                    /**
+                     * Creates new ProfilerService service using the specified rpc implementation.
+                     * @param rpcImpl RPC implementation
+                     * @param [requestDelimited=false] Whether requests are length-delimited
+                     * @param [responseDelimited=false] Whether responses are length-delimited
+                     * @returns RPC service. Useful where requests and/or responses are streamed.
+                     */
+                    public static create(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean): ProfilerService;
+
+                    /**
+                     * Calls CreateProfile.
+                     * @param request CreateProfileRequest message or plain object
+                     * @param callback Node-style callback called with the error, if any, and Profile
+                     */
+                    public createProfile(request: google.devtools.cloudprofiler.v2.ICreateProfileRequest, callback: google.devtools.cloudprofiler.v2.ProfilerService.CreateProfileCallback): void;
+
+                    /**
+                     * Calls CreateProfile.
+                     * @param request CreateProfileRequest message or plain object
+                     * @returns Promise
+                     */
+                    public createProfile(request: google.devtools.cloudprofiler.v2.ICreateProfileRequest): Promise<google.devtools.cloudprofiler.v2.Profile>;
+
+                    /**
+                     * Calls UpdateProfile.
+                     * @param request UpdateProfileRequest message or plain object
+                     * @param callback Node-style callback called with the error, if any, and Profile
+                     */
+                    public updateProfile(request: google.devtools.cloudprofiler.v2.IUpdateProfileRequest, callback: google.devtools.cloudprofiler.v2.ProfilerService.UpdateProfileCallback): void;
+
+                    /**
+                     * Calls UpdateProfile.
+                     * @param request UpdateProfileRequest message or plain object
+                     * @returns Promise
+                     */
+                    public updateProfile(request: google.devtools.cloudprofiler.v2.IUpdateProfileRequest): Promise<google.devtools.cloudprofiler.v2.Profile>;
+                }
+
+                namespace ProfilerService {
+
+                    /**
+                     * Callback as used by {@link google.devtools.cloudprofiler.v2.ProfilerService#createProfile}.
+                     * @param error Error, if any
+                     * @param [response] Profile
+                     */
+                    type CreateProfileCallback = (error: (Error|null), response?: google.devtools.cloudprofiler.v2.Profile) => void;
+
+                    /**
+                     * Callback as used by {@link google.devtools.cloudprofiler.v2.ProfilerService#updateProfile}.
+                     * @param error Error, if any
+                     * @param [response] Profile
+                     */
+                    type UpdateProfileCallback = (error: (Error|null), response?: google.devtools.cloudprofiler.v2.Profile) => void;
+                }
+
+                /** Properties of a CreateProfileRequest. */
+                interface ICreateProfileRequest {
+
+                    /** CreateProfileRequest deployment */
+                    deployment?: google.devtools.cloudprofiler.v2.IDeployment;
+
+                    /** CreateProfileRequest profileType */
+                    profileType?: google.devtools.cloudprofiler.v2.ProfileType[];
+
+                    /** CreateProfileRequest profile */
+                    profile?: google.devtools.cloudprofiler.v2.IProfile;
+                }
+
+                /** Represents a CreateProfileRequest. */
+                class CreateProfileRequest {
+
+                    /**
+                     * Constructs a new CreateProfileRequest.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: google.devtools.cloudprofiler.v2.ICreateProfileRequest);
+
+                    /** CreateProfileRequest deployment. */
+                    public deployment?: (google.devtools.cloudprofiler.v2.IDeployment|null);
+
+                    /** CreateProfileRequest profileType. */
+                    public profileType: google.devtools.cloudprofiler.v2.ProfileType[];
+
+                    /** CreateProfileRequest profile. */
+                    public profile?: (google.devtools.cloudprofiler.v2.IProfile|null);
+
+                    /**
+                     * Creates a new CreateProfileRequest instance using the specified properties.
+                     * @param [properties] Properties to set
+                     * @returns CreateProfileRequest instance
+                     */
+                    public static create(properties?: google.devtools.cloudprofiler.v2.ICreateProfileRequest): google.devtools.cloudprofiler.v2.CreateProfileRequest;
+
+                    /**
+                     * Encodes the specified CreateProfileRequest message. Does not implicitly {@link google.devtools.cloudprofiler.v2.CreateProfileRequest.verify|verify} messages.
+                     * @param message CreateProfileRequest message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encode(message: google.devtools.cloudprofiler.v2.ICreateProfileRequest, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Encodes the specified CreateProfileRequest message, length delimited. Does not implicitly {@link google.devtools.cloudprofiler.v2.CreateProfileRequest.verify|verify} messages.
+                     * @param message CreateProfileRequest message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encodeDelimited(message: google.devtools.cloudprofiler.v2.ICreateProfileRequest, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Decodes a CreateProfileRequest message from the specified reader or buffer.
+                     * @param reader Reader or buffer to decode from
+                     * @param [length] Message length if known beforehand
+                     * @returns CreateProfileRequest
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.devtools.cloudprofiler.v2.CreateProfileRequest;
+
+                    /**
+                     * Decodes a CreateProfileRequest message from the specified reader or buffer, length delimited.
+                     * @param reader Reader or buffer to decode from
+                     * @returns CreateProfileRequest
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.devtools.cloudprofiler.v2.CreateProfileRequest;
+
+                    /**
+                     * Verifies a CreateProfileRequest message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates a CreateProfileRequest message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns CreateProfileRequest
+                     */
+                    public static fromObject(object: { [k: string]: any }): google.devtools.cloudprofiler.v2.CreateProfileRequest;
+
+                    /**
+                     * Creates a plain object from a CreateProfileRequest message. Also converts values to other types if specified.
+                     * @param message CreateProfileRequest
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: google.devtools.cloudprofiler.v2.CreateProfileRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this CreateProfileRequest to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
+
+                /** Properties of an UpdateProfileRequest. */
+                interface IUpdateProfileRequest {
+
+                    /** UpdateProfileRequest profile */
+                    profile?: google.devtools.cloudprofiler.v2.IProfile;
+                }
+
+                /** Represents an UpdateProfileRequest. */
+                class UpdateProfileRequest {
+
+                    /**
+                     * Constructs a new UpdateProfileRequest.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: google.devtools.cloudprofiler.v2.IUpdateProfileRequest);
+
+                    /** UpdateProfileRequest profile. */
+                    public profile?: (google.devtools.cloudprofiler.v2.IProfile|null);
+
+                    /**
+                     * Creates a new UpdateProfileRequest instance using the specified properties.
+                     * @param [properties] Properties to set
+                     * @returns UpdateProfileRequest instance
+                     */
+                    public static create(properties?: google.devtools.cloudprofiler.v2.IUpdateProfileRequest): google.devtools.cloudprofiler.v2.UpdateProfileRequest;
+
+                    /**
+                     * Encodes the specified UpdateProfileRequest message. Does not implicitly {@link google.devtools.cloudprofiler.v2.UpdateProfileRequest.verify|verify} messages.
+                     * @param message UpdateProfileRequest message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encode(message: google.devtools.cloudprofiler.v2.IUpdateProfileRequest, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Encodes the specified UpdateProfileRequest message, length delimited. Does not implicitly {@link google.devtools.cloudprofiler.v2.UpdateProfileRequest.verify|verify} messages.
+                     * @param message UpdateProfileRequest message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encodeDelimited(message: google.devtools.cloudprofiler.v2.IUpdateProfileRequest, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Decodes an UpdateProfileRequest message from the specified reader or buffer.
+                     * @param reader Reader or buffer to decode from
+                     * @param [length] Message length if known beforehand
+                     * @returns UpdateProfileRequest
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.devtools.cloudprofiler.v2.UpdateProfileRequest;
+
+                    /**
+                     * Decodes an UpdateProfileRequest message from the specified reader or buffer, length delimited.
+                     * @param reader Reader or buffer to decode from
+                     * @returns UpdateProfileRequest
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.devtools.cloudprofiler.v2.UpdateProfileRequest;
+
+                    /**
+                     * Verifies an UpdateProfileRequest message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates an UpdateProfileRequest message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns UpdateProfileRequest
+                     */
+                    public static fromObject(object: { [k: string]: any }): google.devtools.cloudprofiler.v2.UpdateProfileRequest;
+
+                    /**
+                     * Creates a plain object from an UpdateProfileRequest message. Also converts values to other types if specified.
+                     * @param message UpdateProfileRequest
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: google.devtools.cloudprofiler.v2.UpdateProfileRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this UpdateProfileRequest to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
+
+                /** Properties of a Profile. */
+                interface IProfile {
+
+                    /** Profile name */
+                    name?: string;
+
+                    /** Profile profileType */
+                    profileType?: google.devtools.cloudprofiler.v2.ProfileType;
+
+                    /** Profile deployment */
+                    deployment?: google.devtools.cloudprofiler.v2.IDeployment;
+
+                    /** Profile duration */
+                    duration?: google.protobuf.IDuration;
+
+                    /** Profile profileBytes */
+                    profileBytes?: Uint8Array;
+
+                    /** Profile labels */
+                    labels?: { [k: string]: string };
+                }
+
+                /** Represents a Profile. */
+                class Profile {
+
+                    /**
+                     * Constructs a new Profile.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: google.devtools.cloudprofiler.v2.IProfile);
+
+                    /** Profile name. */
+                    public name: string;
+
+                    /** Profile profileType. */
+                    public profileType: google.devtools.cloudprofiler.v2.ProfileType;
+
+                    /** Profile deployment. */
+                    public deployment?: (google.devtools.cloudprofiler.v2.IDeployment|null);
+
+                    /** Profile duration. */
+                    public duration?: (google.protobuf.IDuration|null);
+
+                    /** Profile profileBytes. */
+                    public profileBytes: Uint8Array;
+
+                    /** Profile labels. */
+                    public labels: { [k: string]: string };
+
+                    /**
+                     * Creates a new Profile instance using the specified properties.
+                     * @param [properties] Properties to set
+                     * @returns Profile instance
+                     */
+                    public static create(properties?: google.devtools.cloudprofiler.v2.IProfile): google.devtools.cloudprofiler.v2.Profile;
+
+                    /**
+                     * Encodes the specified Profile message. Does not implicitly {@link google.devtools.cloudprofiler.v2.Profile.verify|verify} messages.
+                     * @param message Profile message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encode(message: google.devtools.cloudprofiler.v2.IProfile, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Encodes the specified Profile message, length delimited. Does not implicitly {@link google.devtools.cloudprofiler.v2.Profile.verify|verify} messages.
+                     * @param message Profile message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encodeDelimited(message: google.devtools.cloudprofiler.v2.IProfile, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Decodes a Profile message from the specified reader or buffer.
+                     * @param reader Reader or buffer to decode from
+                     * @param [length] Message length if known beforehand
+                     * @returns Profile
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.devtools.cloudprofiler.v2.Profile;
+
+                    /**
+                     * Decodes a Profile message from the specified reader or buffer, length delimited.
+                     * @param reader Reader or buffer to decode from
+                     * @returns Profile
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.devtools.cloudprofiler.v2.Profile;
+
+                    /**
+                     * Verifies a Profile message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates a Profile message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns Profile
+                     */
+                    public static fromObject(object: { [k: string]: any }): google.devtools.cloudprofiler.v2.Profile;
+
+                    /**
+                     * Creates a plain object from a Profile message. Also converts values to other types if specified.
+                     * @param message Profile
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: google.devtools.cloudprofiler.v2.Profile, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this Profile to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
+
+                /** Properties of a Deployment. */
+                interface IDeployment {
+
+                    /** Deployment projectId */
+                    projectId?: string;
+
+                    /** Deployment target */
+                    target?: string;
+
+                    /** Deployment labels */
+                    labels?: { [k: string]: string };
+                }
+
+                /** Represents a Deployment. */
+                class Deployment {
+
+                    /**
+                     * Constructs a new Deployment.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: google.devtools.cloudprofiler.v2.IDeployment);
+
+                    /** Deployment projectId. */
+                    public projectId: string;
+
+                    /** Deployment target. */
+                    public target: string;
+
+                    /** Deployment labels. */
+                    public labels: { [k: string]: string };
+
+                    /**
+                     * Creates a new Deployment instance using the specified properties.
+                     * @param [properties] Properties to set
+                     * @returns Deployment instance
+                     */
+                    public static create(properties?: google.devtools.cloudprofiler.v2.IDeployment): google.devtools.cloudprofiler.v2.Deployment;
+
+                    /**
+                     * Encodes the specified Deployment message. Does not implicitly {@link google.devtools.cloudprofiler.v2.Deployment.verify|verify} messages.
+                     * @param message Deployment message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encode(message: google.devtools.cloudprofiler.v2.IDeployment, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Encodes the specified Deployment message, length delimited. Does not implicitly {@link google.devtools.cloudprofiler.v2.Deployment.verify|verify} messages.
+                     * @param message Deployment message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encodeDelimited(message: google.devtools.cloudprofiler.v2.IDeployment, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Decodes a Deployment message from the specified reader or buffer.
+                     * @param reader Reader or buffer to decode from
+                     * @param [length] Message length if known beforehand
+                     * @returns Deployment
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.devtools.cloudprofiler.v2.Deployment;
+
+                    /**
+                     * Decodes a Deployment message from the specified reader or buffer, length delimited.
+                     * @param reader Reader or buffer to decode from
+                     * @returns Deployment
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.devtools.cloudprofiler.v2.Deployment;
+
+                    /**
+                     * Verifies a Deployment message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates a Deployment message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns Deployment
+                     */
+                    public static fromObject(object: { [k: string]: any }): google.devtools.cloudprofiler.v2.Deployment;
+
+                    /**
+                     * Creates a plain object from a Deployment message. Also converts values to other types if specified.
+                     * @param message Deployment
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: google.devtools.cloudprofiler.v2.Deployment, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this Deployment to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
+
+                /** ProfileType enum. */
+                enum ProfileType {
+                    PROFILE_TYPE_UNSPECIFIED = 0,
+                    CPU = 1,
+                    WALL = 2,
+                    HEAP = 3,
+                    THREADS = 4,
+                    CONTENTION = 5
+                }
+            }
+        }
+    }
+
+    /** Namespace api. */
+    namespace api {
+
+        /** Properties of a Http. */
+        interface IHttp {
+
+            /** Http rules */
+            rules?: google.api.IHttpRule[];
+        }
+
+        /** Represents a Http. */
+        class Http {
+
+            /**
+             * Constructs a new Http.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.api.IHttp);
+
+            /** Http rules. */
+            public rules: google.api.IHttpRule[];
+
+            /**
+             * Creates a new Http instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns Http instance
+             */
+            public static create(properties?: google.api.IHttp): google.api.Http;
+
+            /**
+             * Encodes the specified Http message. Does not implicitly {@link google.api.Http.verify|verify} messages.
+             * @param message Http message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.api.IHttp, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified Http message, length delimited. Does not implicitly {@link google.api.Http.verify|verify} messages.
+             * @param message Http message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.api.IHttp, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a Http message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns Http
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.api.Http;
+
+            /**
+             * Decodes a Http message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns Http
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.api.Http;
+
+            /**
+             * Verifies a Http message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a Http message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns Http
+             */
+            public static fromObject(object: { [k: string]: any }): google.api.Http;
+
+            /**
+             * Creates a plain object from a Http message. Also converts values to other types if specified.
+             * @param message Http
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.api.Http, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this Http to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a HttpRule. */
+        interface IHttpRule {
+
+            /** HttpRule get */
+            get?: string;
+
+            /** HttpRule put */
+            put?: string;
+
+            /** HttpRule post */
+            post?: string;
+
+            /** HttpRule delete */
+            "delete"?: string;
+
+            /** HttpRule patch */
+            patch?: string;
+
+            /** HttpRule custom */
+            custom?: google.api.ICustomHttpPattern;
+
+            /** HttpRule selector */
+            selector?: string;
+
+            /** HttpRule body */
+            body?: string;
+
+            /** HttpRule additionalBindings */
+            additionalBindings?: google.api.IHttpRule[];
+        }
+
+        /** Represents a HttpRule. */
+        class HttpRule {
+
+            /**
+             * Constructs a new HttpRule.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.api.IHttpRule);
+
+            /** HttpRule get. */
+            public get: string;
+
+            /** HttpRule put. */
+            public put: string;
+
+            /** HttpRule post. */
+            public post: string;
+
+            /** HttpRule delete. */
+            public delete_: string;
+
+            /** HttpRule patch. */
+            public patch: string;
+
+            /** HttpRule custom. */
+            public custom?: (google.api.ICustomHttpPattern|null);
+
+            /** HttpRule selector. */
+            public selector: string;
+
+            /** HttpRule body. */
+            public body: string;
+
+            /** HttpRule additionalBindings. */
+            public additionalBindings: google.api.IHttpRule[];
+
+            /** HttpRule pattern. */
+            public pattern?: string;
+
+            /**
+             * Creates a new HttpRule instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns HttpRule instance
+             */
+            public static create(properties?: google.api.IHttpRule): google.api.HttpRule;
+
+            /**
+             * Encodes the specified HttpRule message. Does not implicitly {@link google.api.HttpRule.verify|verify} messages.
+             * @param message HttpRule message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.api.IHttpRule, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified HttpRule message, length delimited. Does not implicitly {@link google.api.HttpRule.verify|verify} messages.
+             * @param message HttpRule message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.api.IHttpRule, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a HttpRule message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns HttpRule
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.api.HttpRule;
+
+            /**
+             * Decodes a HttpRule message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns HttpRule
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.api.HttpRule;
+
+            /**
+             * Verifies a HttpRule message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a HttpRule message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns HttpRule
+             */
+            public static fromObject(object: { [k: string]: any }): google.api.HttpRule;
+
+            /**
+             * Creates a plain object from a HttpRule message. Also converts values to other types if specified.
+             * @param message HttpRule
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.api.HttpRule, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this HttpRule to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a CustomHttpPattern. */
+        interface ICustomHttpPattern {
+
+            /** CustomHttpPattern kind */
+            kind?: string;
+
+            /** CustomHttpPattern path */
+            path?: string;
+        }
+
+        /** Represents a CustomHttpPattern. */
+        class CustomHttpPattern {
+
+            /**
+             * Constructs a new CustomHttpPattern.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.api.ICustomHttpPattern);
+
+            /** CustomHttpPattern kind. */
+            public kind: string;
+
+            /** CustomHttpPattern path. */
+            public path: string;
+
+            /**
+             * Creates a new CustomHttpPattern instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns CustomHttpPattern instance
+             */
+            public static create(properties?: google.api.ICustomHttpPattern): google.api.CustomHttpPattern;
+
+            /**
+             * Encodes the specified CustomHttpPattern message. Does not implicitly {@link google.api.CustomHttpPattern.verify|verify} messages.
+             * @param message CustomHttpPattern message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.api.ICustomHttpPattern, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified CustomHttpPattern message, length delimited. Does not implicitly {@link google.api.CustomHttpPattern.verify|verify} messages.
+             * @param message CustomHttpPattern message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.api.ICustomHttpPattern, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a CustomHttpPattern message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns CustomHttpPattern
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.api.CustomHttpPattern;
+
+            /**
+             * Decodes a CustomHttpPattern message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns CustomHttpPattern
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.api.CustomHttpPattern;
+
+            /**
+             * Verifies a CustomHttpPattern message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a CustomHttpPattern message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns CustomHttpPattern
+             */
+            public static fromObject(object: { [k: string]: any }): google.api.CustomHttpPattern;
+
+            /**
+             * Creates a plain object from a CustomHttpPattern message. Also converts values to other types if specified.
+             * @param message CustomHttpPattern
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.api.CustomHttpPattern, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this CustomHttpPattern to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+    }
+
+    /** Namespace protobuf. */
+    namespace protobuf {
+
+        /** Properties of a FileDescriptorSet. */
+        interface IFileDescriptorSet {
+
+            /** FileDescriptorSet file */
+            file?: google.protobuf.IFileDescriptorProto[];
+        }
+
+        /** Represents a FileDescriptorSet. */
+        class FileDescriptorSet {
+
+            /**
+             * Constructs a new FileDescriptorSet.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IFileDescriptorSet);
+
+            /** FileDescriptorSet file. */
+            public file: google.protobuf.IFileDescriptorProto[];
+
+            /**
+             * Creates a new FileDescriptorSet instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns FileDescriptorSet instance
+             */
+            public static create(properties?: google.protobuf.IFileDescriptorSet): google.protobuf.FileDescriptorSet;
+
+            /**
+             * Encodes the specified FileDescriptorSet message. Does not implicitly {@link google.protobuf.FileDescriptorSet.verify|verify} messages.
+             * @param message FileDescriptorSet message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IFileDescriptorSet, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified FileDescriptorSet message, length delimited. Does not implicitly {@link google.protobuf.FileDescriptorSet.verify|verify} messages.
+             * @param message FileDescriptorSet message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IFileDescriptorSet, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a FileDescriptorSet message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns FileDescriptorSet
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.FileDescriptorSet;
+
+            /**
+             * Decodes a FileDescriptorSet message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns FileDescriptorSet
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.FileDescriptorSet;
+
+            /**
+             * Verifies a FileDescriptorSet message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a FileDescriptorSet message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns FileDescriptorSet
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.FileDescriptorSet;
+
+            /**
+             * Creates a plain object from a FileDescriptorSet message. Also converts values to other types if specified.
+             * @param message FileDescriptorSet
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.FileDescriptorSet, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this FileDescriptorSet to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a FileDescriptorProto. */
+        interface IFileDescriptorProto {
+
+            /** FileDescriptorProto name */
+            name?: string;
+
+            /** FileDescriptorProto package */
+            "package"?: string;
+
+            /** FileDescriptorProto dependency */
+            dependency?: string[];
+
+            /** FileDescriptorProto publicDependency */
+            publicDependency?: number[];
+
+            /** FileDescriptorProto weakDependency */
+            weakDependency?: number[];
+
+            /** FileDescriptorProto messageType */
+            messageType?: google.protobuf.IDescriptorProto[];
+
+            /** FileDescriptorProto enumType */
+            enumType?: google.protobuf.IEnumDescriptorProto[];
+
+            /** FileDescriptorProto service */
+            service?: google.protobuf.IServiceDescriptorProto[];
+
+            /** FileDescriptorProto extension */
+            extension?: google.protobuf.IFieldDescriptorProto[];
+
+            /** FileDescriptorProto options */
+            options?: google.protobuf.IFileOptions;
+
+            /** FileDescriptorProto sourceCodeInfo */
+            sourceCodeInfo?: google.protobuf.ISourceCodeInfo;
+
+            /** FileDescriptorProto syntax */
+            syntax?: string;
+        }
+
+        /** Represents a FileDescriptorProto. */
+        class FileDescriptorProto {
+
+            /**
+             * Constructs a new FileDescriptorProto.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IFileDescriptorProto);
+
+            /** FileDescriptorProto name. */
+            public name: string;
+
+            /** FileDescriptorProto package. */
+            public package_: string;
+
+            /** FileDescriptorProto dependency. */
+            public dependency: string[];
+
+            /** FileDescriptorProto publicDependency. */
+            public publicDependency: number[];
+
+            /** FileDescriptorProto weakDependency. */
+            public weakDependency: number[];
+
+            /** FileDescriptorProto messageType. */
+            public messageType: google.protobuf.IDescriptorProto[];
+
+            /** FileDescriptorProto enumType. */
+            public enumType: google.protobuf.IEnumDescriptorProto[];
+
+            /** FileDescriptorProto service. */
+            public service: google.protobuf.IServiceDescriptorProto[];
+
+            /** FileDescriptorProto extension. */
+            public extension: google.protobuf.IFieldDescriptorProto[];
+
+            /** FileDescriptorProto options. */
+            public options?: (google.protobuf.IFileOptions|null);
+
+            /** FileDescriptorProto sourceCodeInfo. */
+            public sourceCodeInfo?: (google.protobuf.ISourceCodeInfo|null);
+
+            /** FileDescriptorProto syntax. */
+            public syntax: string;
+
+            /**
+             * Creates a new FileDescriptorProto instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns FileDescriptorProto instance
+             */
+            public static create(properties?: google.protobuf.IFileDescriptorProto): google.protobuf.FileDescriptorProto;
+
+            /**
+             * Encodes the specified FileDescriptorProto message. Does not implicitly {@link google.protobuf.FileDescriptorProto.verify|verify} messages.
+             * @param message FileDescriptorProto message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IFileDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified FileDescriptorProto message, length delimited. Does not implicitly {@link google.protobuf.FileDescriptorProto.verify|verify} messages.
+             * @param message FileDescriptorProto message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IFileDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a FileDescriptorProto message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns FileDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.FileDescriptorProto;
+
+            /**
+             * Decodes a FileDescriptorProto message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns FileDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.FileDescriptorProto;
+
+            /**
+             * Verifies a FileDescriptorProto message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a FileDescriptorProto message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns FileDescriptorProto
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.FileDescriptorProto;
+
+            /**
+             * Creates a plain object from a FileDescriptorProto message. Also converts values to other types if specified.
+             * @param message FileDescriptorProto
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.FileDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this FileDescriptorProto to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a DescriptorProto. */
+        interface IDescriptorProto {
+
+            /** DescriptorProto name */
+            name?: string;
+
+            /** DescriptorProto field */
+            field?: google.protobuf.IFieldDescriptorProto[];
+
+            /** DescriptorProto extension */
+            extension?: google.protobuf.IFieldDescriptorProto[];
+
+            /** DescriptorProto nestedType */
+            nestedType?: google.protobuf.IDescriptorProto[];
+
+            /** DescriptorProto enumType */
+            enumType?: google.protobuf.IEnumDescriptorProto[];
+
+            /** DescriptorProto extensionRange */
+            extensionRange?: google.protobuf.DescriptorProto.IExtensionRange[];
+
+            /** DescriptorProto oneofDecl */
+            oneofDecl?: google.protobuf.IOneofDescriptorProto[];
+
+            /** DescriptorProto options */
+            options?: google.protobuf.IMessageOptions;
+
+            /** DescriptorProto reservedRange */
+            reservedRange?: google.protobuf.DescriptorProto.IReservedRange[];
+
+            /** DescriptorProto reservedName */
+            reservedName?: string[];
+        }
+
+        /** Represents a DescriptorProto. */
+        class DescriptorProto {
+
+            /**
+             * Constructs a new DescriptorProto.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IDescriptorProto);
+
+            /** DescriptorProto name. */
+            public name: string;
+
+            /** DescriptorProto field. */
+            public field: google.protobuf.IFieldDescriptorProto[];
+
+            /** DescriptorProto extension. */
+            public extension: google.protobuf.IFieldDescriptorProto[];
+
+            /** DescriptorProto nestedType. */
+            public nestedType: google.protobuf.IDescriptorProto[];
+
+            /** DescriptorProto enumType. */
+            public enumType: google.protobuf.IEnumDescriptorProto[];
+
+            /** DescriptorProto extensionRange. */
+            public extensionRange: google.protobuf.DescriptorProto.IExtensionRange[];
+
+            /** DescriptorProto oneofDecl. */
+            public oneofDecl: google.protobuf.IOneofDescriptorProto[];
+
+            /** DescriptorProto options. */
+            public options?: (google.protobuf.IMessageOptions|null);
+
+            /** DescriptorProto reservedRange. */
+            public reservedRange: google.protobuf.DescriptorProto.IReservedRange[];
+
+            /** DescriptorProto reservedName. */
+            public reservedName: string[];
+
+            /**
+             * Creates a new DescriptorProto instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns DescriptorProto instance
+             */
+            public static create(properties?: google.protobuf.IDescriptorProto): google.protobuf.DescriptorProto;
+
+            /**
+             * Encodes the specified DescriptorProto message. Does not implicitly {@link google.protobuf.DescriptorProto.verify|verify} messages.
+             * @param message DescriptorProto message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified DescriptorProto message, length delimited. Does not implicitly {@link google.protobuf.DescriptorProto.verify|verify} messages.
+             * @param message DescriptorProto message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a DescriptorProto message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns DescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.DescriptorProto;
+
+            /**
+             * Decodes a DescriptorProto message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns DescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.DescriptorProto;
+
+            /**
+             * Verifies a DescriptorProto message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a DescriptorProto message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns DescriptorProto
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.DescriptorProto;
+
+            /**
+             * Creates a plain object from a DescriptorProto message. Also converts values to other types if specified.
+             * @param message DescriptorProto
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.DescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this DescriptorProto to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        namespace DescriptorProto {
+
+            /** Properties of an ExtensionRange. */
+            interface IExtensionRange {
+
+                /** ExtensionRange start */
+                start?: number;
+
+                /** ExtensionRange end */
+                end?: number;
+            }
+
+            /** Represents an ExtensionRange. */
+            class ExtensionRange {
+
+                /**
+                 * Constructs a new ExtensionRange.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.protobuf.DescriptorProto.IExtensionRange);
+
+                /** ExtensionRange start. */
+                public start: number;
+
+                /** ExtensionRange end. */
+                public end: number;
+
+                /**
+                 * Creates a new ExtensionRange instance using the specified properties.
+                 * @param [properties] Properties to set
+                 * @returns ExtensionRange instance
+                 */
+                public static create(properties?: google.protobuf.DescriptorProto.IExtensionRange): google.protobuf.DescriptorProto.ExtensionRange;
+
+                /**
+                 * Encodes the specified ExtensionRange message. Does not implicitly {@link google.protobuf.DescriptorProto.ExtensionRange.verify|verify} messages.
+                 * @param message ExtensionRange message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encode(message: google.protobuf.DescriptorProto.IExtensionRange, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Encodes the specified ExtensionRange message, length delimited. Does not implicitly {@link google.protobuf.DescriptorProto.ExtensionRange.verify|verify} messages.
+                 * @param message ExtensionRange message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encodeDelimited(message: google.protobuf.DescriptorProto.IExtensionRange, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Decodes an ExtensionRange message from the specified reader or buffer.
+                 * @param reader Reader or buffer to decode from
+                 * @param [length] Message length if known beforehand
+                 * @returns ExtensionRange
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.DescriptorProto.ExtensionRange;
+
+                /**
+                 * Decodes an ExtensionRange message from the specified reader or buffer, length delimited.
+                 * @param reader Reader or buffer to decode from
+                 * @returns ExtensionRange
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.DescriptorProto.ExtensionRange;
+
+                /**
+                 * Verifies an ExtensionRange message.
+                 * @param message Plain object to verify
+                 * @returns `null` if valid, otherwise the reason why it is not
+                 */
+                public static verify(message: { [k: string]: any }): (string|null);
+
+                /**
+                 * Creates an ExtensionRange message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns ExtensionRange
+                 */
+                public static fromObject(object: { [k: string]: any }): google.protobuf.DescriptorProto.ExtensionRange;
+
+                /**
+                 * Creates a plain object from an ExtensionRange message. Also converts values to other types if specified.
+                 * @param message ExtensionRange
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: google.protobuf.DescriptorProto.ExtensionRange, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this ExtensionRange to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
+
+            /** Properties of a ReservedRange. */
+            interface IReservedRange {
+
+                /** ReservedRange start */
+                start?: number;
+
+                /** ReservedRange end */
+                end?: number;
+            }
+
+            /** Represents a ReservedRange. */
+            class ReservedRange {
+
+                /**
+                 * Constructs a new ReservedRange.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.protobuf.DescriptorProto.IReservedRange);
+
+                /** ReservedRange start. */
+                public start: number;
+
+                /** ReservedRange end. */
+                public end: number;
+
+                /**
+                 * Creates a new ReservedRange instance using the specified properties.
+                 * @param [properties] Properties to set
+                 * @returns ReservedRange instance
+                 */
+                public static create(properties?: google.protobuf.DescriptorProto.IReservedRange): google.protobuf.DescriptorProto.ReservedRange;
+
+                /**
+                 * Encodes the specified ReservedRange message. Does not implicitly {@link google.protobuf.DescriptorProto.ReservedRange.verify|verify} messages.
+                 * @param message ReservedRange message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encode(message: google.protobuf.DescriptorProto.IReservedRange, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Encodes the specified ReservedRange message, length delimited. Does not implicitly {@link google.protobuf.DescriptorProto.ReservedRange.verify|verify} messages.
+                 * @param message ReservedRange message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encodeDelimited(message: google.protobuf.DescriptorProto.IReservedRange, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Decodes a ReservedRange message from the specified reader or buffer.
+                 * @param reader Reader or buffer to decode from
+                 * @param [length] Message length if known beforehand
+                 * @returns ReservedRange
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.DescriptorProto.ReservedRange;
+
+                /**
+                 * Decodes a ReservedRange message from the specified reader or buffer, length delimited.
+                 * @param reader Reader or buffer to decode from
+                 * @returns ReservedRange
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.DescriptorProto.ReservedRange;
+
+                /**
+                 * Verifies a ReservedRange message.
+                 * @param message Plain object to verify
+                 * @returns `null` if valid, otherwise the reason why it is not
+                 */
+                public static verify(message: { [k: string]: any }): (string|null);
+
+                /**
+                 * Creates a ReservedRange message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns ReservedRange
+                 */
+                public static fromObject(object: { [k: string]: any }): google.protobuf.DescriptorProto.ReservedRange;
+
+                /**
+                 * Creates a plain object from a ReservedRange message. Also converts values to other types if specified.
+                 * @param message ReservedRange
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: google.protobuf.DescriptorProto.ReservedRange, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this ReservedRange to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
+        }
+
+        /** Properties of a FieldDescriptorProto. */
+        interface IFieldDescriptorProto {
+
+            /** FieldDescriptorProto name */
+            name?: string;
+
+            /** FieldDescriptorProto number */
+            number?: number;
+
+            /** FieldDescriptorProto label */
+            label?: google.protobuf.FieldDescriptorProto.Label;
+
+            /** FieldDescriptorProto type */
+            type?: google.protobuf.FieldDescriptorProto.Type;
+
+            /** FieldDescriptorProto typeName */
+            typeName?: string;
+
+            /** FieldDescriptorProto extendee */
+            extendee?: string;
+
+            /** FieldDescriptorProto defaultValue */
+            defaultValue?: string;
+
+            /** FieldDescriptorProto oneofIndex */
+            oneofIndex?: number;
+
+            /** FieldDescriptorProto jsonName */
+            jsonName?: string;
+
+            /** FieldDescriptorProto options */
+            options?: google.protobuf.IFieldOptions;
+        }
+
+        /** Represents a FieldDescriptorProto. */
+        class FieldDescriptorProto {
+
+            /**
+             * Constructs a new FieldDescriptorProto.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IFieldDescriptorProto);
+
+            /** FieldDescriptorProto name. */
+            public name: string;
+
+            /** FieldDescriptorProto number. */
+            public number: number;
+
+            /** FieldDescriptorProto label. */
+            public label: google.protobuf.FieldDescriptorProto.Label;
+
+            /** FieldDescriptorProto type. */
+            public type: google.protobuf.FieldDescriptorProto.Type;
+
+            /** FieldDescriptorProto typeName. */
+            public typeName: string;
+
+            /** FieldDescriptorProto extendee. */
+            public extendee: string;
+
+            /** FieldDescriptorProto defaultValue. */
+            public defaultValue: string;
+
+            /** FieldDescriptorProto oneofIndex. */
+            public oneofIndex: number;
+
+            /** FieldDescriptorProto jsonName. */
+            public jsonName: string;
+
+            /** FieldDescriptorProto options. */
+            public options?: (google.protobuf.IFieldOptions|null);
+
+            /**
+             * Creates a new FieldDescriptorProto instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns FieldDescriptorProto instance
+             */
+            public static create(properties?: google.protobuf.IFieldDescriptorProto): google.protobuf.FieldDescriptorProto;
+
+            /**
+             * Encodes the specified FieldDescriptorProto message. Does not implicitly {@link google.protobuf.FieldDescriptorProto.verify|verify} messages.
+             * @param message FieldDescriptorProto message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IFieldDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified FieldDescriptorProto message, length delimited. Does not implicitly {@link google.protobuf.FieldDescriptorProto.verify|verify} messages.
+             * @param message FieldDescriptorProto message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IFieldDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a FieldDescriptorProto message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns FieldDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.FieldDescriptorProto;
+
+            /**
+             * Decodes a FieldDescriptorProto message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns FieldDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.FieldDescriptorProto;
+
+            /**
+             * Verifies a FieldDescriptorProto message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a FieldDescriptorProto message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns FieldDescriptorProto
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.FieldDescriptorProto;
+
+            /**
+             * Creates a plain object from a FieldDescriptorProto message. Also converts values to other types if specified.
+             * @param message FieldDescriptorProto
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.FieldDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this FieldDescriptorProto to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        namespace FieldDescriptorProto {
+
+            /** Type enum. */
+            enum Type {
+                TYPE_DOUBLE = 1,
+                TYPE_FLOAT = 2,
+                TYPE_INT64 = 3,
+                TYPE_UINT64 = 4,
+                TYPE_INT32 = 5,
+                TYPE_FIXED64 = 6,
+                TYPE_FIXED32 = 7,
+                TYPE_BOOL = 8,
+                TYPE_STRING = 9,
+                TYPE_GROUP = 10,
+                TYPE_MESSAGE = 11,
+                TYPE_BYTES = 12,
+                TYPE_UINT32 = 13,
+                TYPE_ENUM = 14,
+                TYPE_SFIXED32 = 15,
+                TYPE_SFIXED64 = 16,
+                TYPE_SINT32 = 17,
+                TYPE_SINT64 = 18
+            }
+
+            /** Label enum. */
+            enum Label {
+                LABEL_OPTIONAL = 1,
+                LABEL_REQUIRED = 2,
+                LABEL_REPEATED = 3
+            }
+        }
+
+        /** Properties of an OneofDescriptorProto. */
+        interface IOneofDescriptorProto {
+
+            /** OneofDescriptorProto name */
+            name?: string;
+
+            /** OneofDescriptorProto options */
+            options?: google.protobuf.IOneofOptions;
+        }
+
+        /** Represents an OneofDescriptorProto. */
+        class OneofDescriptorProto {
+
+            /**
+             * Constructs a new OneofDescriptorProto.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IOneofDescriptorProto);
+
+            /** OneofDescriptorProto name. */
+            public name: string;
+
+            /** OneofDescriptorProto options. */
+            public options?: (google.protobuf.IOneofOptions|null);
+
+            /**
+             * Creates a new OneofDescriptorProto instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns OneofDescriptorProto instance
+             */
+            public static create(properties?: google.protobuf.IOneofDescriptorProto): google.protobuf.OneofDescriptorProto;
+
+            /**
+             * Encodes the specified OneofDescriptorProto message. Does not implicitly {@link google.protobuf.OneofDescriptorProto.verify|verify} messages.
+             * @param message OneofDescriptorProto message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IOneofDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified OneofDescriptorProto message, length delimited. Does not implicitly {@link google.protobuf.OneofDescriptorProto.verify|verify} messages.
+             * @param message OneofDescriptorProto message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IOneofDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes an OneofDescriptorProto message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns OneofDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.OneofDescriptorProto;
+
+            /**
+             * Decodes an OneofDescriptorProto message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns OneofDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.OneofDescriptorProto;
+
+            /**
+             * Verifies an OneofDescriptorProto message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates an OneofDescriptorProto message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns OneofDescriptorProto
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.OneofDescriptorProto;
+
+            /**
+             * Creates a plain object from an OneofDescriptorProto message. Also converts values to other types if specified.
+             * @param message OneofDescriptorProto
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.OneofDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this OneofDescriptorProto to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of an EnumDescriptorProto. */
+        interface IEnumDescriptorProto {
+
+            /** EnumDescriptorProto name */
+            name?: string;
+
+            /** EnumDescriptorProto value */
+            value?: google.protobuf.IEnumValueDescriptorProto[];
+
+            /** EnumDescriptorProto options */
+            options?: google.protobuf.IEnumOptions;
+        }
+
+        /** Represents an EnumDescriptorProto. */
+        class EnumDescriptorProto {
+
+            /**
+             * Constructs a new EnumDescriptorProto.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IEnumDescriptorProto);
+
+            /** EnumDescriptorProto name. */
+            public name: string;
+
+            /** EnumDescriptorProto value. */
+            public value: google.protobuf.IEnumValueDescriptorProto[];
+
+            /** EnumDescriptorProto options. */
+            public options?: (google.protobuf.IEnumOptions|null);
+
+            /**
+             * Creates a new EnumDescriptorProto instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns EnumDescriptorProto instance
+             */
+            public static create(properties?: google.protobuf.IEnumDescriptorProto): google.protobuf.EnumDescriptorProto;
+
+            /**
+             * Encodes the specified EnumDescriptorProto message. Does not implicitly {@link google.protobuf.EnumDescriptorProto.verify|verify} messages.
+             * @param message EnumDescriptorProto message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IEnumDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified EnumDescriptorProto message, length delimited. Does not implicitly {@link google.protobuf.EnumDescriptorProto.verify|verify} messages.
+             * @param message EnumDescriptorProto message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IEnumDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes an EnumDescriptorProto message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns EnumDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.EnumDescriptorProto;
+
+            /**
+             * Decodes an EnumDescriptorProto message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns EnumDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.EnumDescriptorProto;
+
+            /**
+             * Verifies an EnumDescriptorProto message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates an EnumDescriptorProto message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns EnumDescriptorProto
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.EnumDescriptorProto;
+
+            /**
+             * Creates a plain object from an EnumDescriptorProto message. Also converts values to other types if specified.
+             * @param message EnumDescriptorProto
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.EnumDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this EnumDescriptorProto to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of an EnumValueDescriptorProto. */
+        interface IEnumValueDescriptorProto {
+
+            /** EnumValueDescriptorProto name */
+            name?: string;
+
+            /** EnumValueDescriptorProto number */
+            number?: number;
+
+            /** EnumValueDescriptorProto options */
+            options?: google.protobuf.IEnumValueOptions;
+        }
+
+        /** Represents an EnumValueDescriptorProto. */
+        class EnumValueDescriptorProto {
+
+            /**
+             * Constructs a new EnumValueDescriptorProto.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IEnumValueDescriptorProto);
+
+            /** EnumValueDescriptorProto name. */
+            public name: string;
+
+            /** EnumValueDescriptorProto number. */
+            public number: number;
+
+            /** EnumValueDescriptorProto options. */
+            public options?: (google.protobuf.IEnumValueOptions|null);
+
+            /**
+             * Creates a new EnumValueDescriptorProto instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns EnumValueDescriptorProto instance
+             */
+            public static create(properties?: google.protobuf.IEnumValueDescriptorProto): google.protobuf.EnumValueDescriptorProto;
+
+            /**
+             * Encodes the specified EnumValueDescriptorProto message. Does not implicitly {@link google.protobuf.EnumValueDescriptorProto.verify|verify} messages.
+             * @param message EnumValueDescriptorProto message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IEnumValueDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified EnumValueDescriptorProto message, length delimited. Does not implicitly {@link google.protobuf.EnumValueDescriptorProto.verify|verify} messages.
+             * @param message EnumValueDescriptorProto message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IEnumValueDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes an EnumValueDescriptorProto message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns EnumValueDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.EnumValueDescriptorProto;
+
+            /**
+             * Decodes an EnumValueDescriptorProto message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns EnumValueDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.EnumValueDescriptorProto;
+
+            /**
+             * Verifies an EnumValueDescriptorProto message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates an EnumValueDescriptorProto message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns EnumValueDescriptorProto
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.EnumValueDescriptorProto;
+
+            /**
+             * Creates a plain object from an EnumValueDescriptorProto message. Also converts values to other types if specified.
+             * @param message EnumValueDescriptorProto
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.EnumValueDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this EnumValueDescriptorProto to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a ServiceDescriptorProto. */
+        interface IServiceDescriptorProto {
+
+            /** ServiceDescriptorProto name */
+            name?: string;
+
+            /** ServiceDescriptorProto method */
+            method?: google.protobuf.IMethodDescriptorProto[];
+
+            /** ServiceDescriptorProto options */
+            options?: google.protobuf.IServiceOptions;
+        }
+
+        /** Represents a ServiceDescriptorProto. */
+        class ServiceDescriptorProto {
+
+            /**
+             * Constructs a new ServiceDescriptorProto.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IServiceDescriptorProto);
+
+            /** ServiceDescriptorProto name. */
+            public name: string;
+
+            /** ServiceDescriptorProto method. */
+            public method: google.protobuf.IMethodDescriptorProto[];
+
+            /** ServiceDescriptorProto options. */
+            public options?: (google.protobuf.IServiceOptions|null);
+
+            /**
+             * Creates a new ServiceDescriptorProto instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns ServiceDescriptorProto instance
+             */
+            public static create(properties?: google.protobuf.IServiceDescriptorProto): google.protobuf.ServiceDescriptorProto;
+
+            /**
+             * Encodes the specified ServiceDescriptorProto message. Does not implicitly {@link google.protobuf.ServiceDescriptorProto.verify|verify} messages.
+             * @param message ServiceDescriptorProto message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IServiceDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified ServiceDescriptorProto message, length delimited. Does not implicitly {@link google.protobuf.ServiceDescriptorProto.verify|verify} messages.
+             * @param message ServiceDescriptorProto message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IServiceDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a ServiceDescriptorProto message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns ServiceDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.ServiceDescriptorProto;
+
+            /**
+             * Decodes a ServiceDescriptorProto message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns ServiceDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.ServiceDescriptorProto;
+
+            /**
+             * Verifies a ServiceDescriptorProto message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a ServiceDescriptorProto message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns ServiceDescriptorProto
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.ServiceDescriptorProto;
+
+            /**
+             * Creates a plain object from a ServiceDescriptorProto message. Also converts values to other types if specified.
+             * @param message ServiceDescriptorProto
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.ServiceDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this ServiceDescriptorProto to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a MethodDescriptorProto. */
+        interface IMethodDescriptorProto {
+
+            /** MethodDescriptorProto name */
+            name?: string;
+
+            /** MethodDescriptorProto inputType */
+            inputType?: string;
+
+            /** MethodDescriptorProto outputType */
+            outputType?: string;
+
+            /** MethodDescriptorProto options */
+            options?: google.protobuf.IMethodOptions;
+
+            /** MethodDescriptorProto clientStreaming */
+            clientStreaming?: boolean;
+
+            /** MethodDescriptorProto serverStreaming */
+            serverStreaming?: boolean;
+        }
+
+        /** Represents a MethodDescriptorProto. */
+        class MethodDescriptorProto {
+
+            /**
+             * Constructs a new MethodDescriptorProto.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IMethodDescriptorProto);
+
+            /** MethodDescriptorProto name. */
+            public name: string;
+
+            /** MethodDescriptorProto inputType. */
+            public inputType: string;
+
+            /** MethodDescriptorProto outputType. */
+            public outputType: string;
+
+            /** MethodDescriptorProto options. */
+            public options?: (google.protobuf.IMethodOptions|null);
+
+            /** MethodDescriptorProto clientStreaming. */
+            public clientStreaming: boolean;
+
+            /** MethodDescriptorProto serverStreaming. */
+            public serverStreaming: boolean;
+
+            /**
+             * Creates a new MethodDescriptorProto instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns MethodDescriptorProto instance
+             */
+            public static create(properties?: google.protobuf.IMethodDescriptorProto): google.protobuf.MethodDescriptorProto;
+
+            /**
+             * Encodes the specified MethodDescriptorProto message. Does not implicitly {@link google.protobuf.MethodDescriptorProto.verify|verify} messages.
+             * @param message MethodDescriptorProto message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IMethodDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified MethodDescriptorProto message, length delimited. Does not implicitly {@link google.protobuf.MethodDescriptorProto.verify|verify} messages.
+             * @param message MethodDescriptorProto message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IMethodDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a MethodDescriptorProto message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns MethodDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.MethodDescriptorProto;
+
+            /**
+             * Decodes a MethodDescriptorProto message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns MethodDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.MethodDescriptorProto;
+
+            /**
+             * Verifies a MethodDescriptorProto message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a MethodDescriptorProto message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns MethodDescriptorProto
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.MethodDescriptorProto;
+
+            /**
+             * Creates a plain object from a MethodDescriptorProto message. Also converts values to other types if specified.
+             * @param message MethodDescriptorProto
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.MethodDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this MethodDescriptorProto to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a FileOptions. */
+        interface IFileOptions {
+
+            /** FileOptions javaPackage */
+            javaPackage?: string;
+
+            /** FileOptions javaOuterClassname */
+            javaOuterClassname?: string;
+
+            /** FileOptions javaMultipleFiles */
+            javaMultipleFiles?: boolean;
+
+            /** FileOptions javaGenerateEqualsAndHash */
+            javaGenerateEqualsAndHash?: boolean;
+
+            /** FileOptions javaStringCheckUtf8 */
+            javaStringCheckUtf8?: boolean;
+
+            /** FileOptions optimizeFor */
+            optimizeFor?: google.protobuf.FileOptions.OptimizeMode;
+
+            /** FileOptions goPackage */
+            goPackage?: string;
+
+            /** FileOptions ccGenericServices */
+            ccGenericServices?: boolean;
+
+            /** FileOptions javaGenericServices */
+            javaGenericServices?: boolean;
+
+            /** FileOptions pyGenericServices */
+            pyGenericServices?: boolean;
+
+            /** FileOptions deprecated */
+            deprecated?: boolean;
+
+            /** FileOptions ccEnableArenas */
+            ccEnableArenas?: boolean;
+
+            /** FileOptions objcClassPrefix */
+            objcClassPrefix?: string;
+
+            /** FileOptions csharpNamespace */
+            csharpNamespace?: string;
+
+            /** FileOptions uninterpretedOption */
+            uninterpretedOption?: google.protobuf.IUninterpretedOption[];
+        }
+
+        /** Represents a FileOptions. */
+        class FileOptions {
+
+            /**
+             * Constructs a new FileOptions.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IFileOptions);
+
+            /** FileOptions javaPackage. */
+            public javaPackage: string;
+
+            /** FileOptions javaOuterClassname. */
+            public javaOuterClassname: string;
+
+            /** FileOptions javaMultipleFiles. */
+            public javaMultipleFiles: boolean;
+
+            /** FileOptions javaGenerateEqualsAndHash. */
+            public javaGenerateEqualsAndHash: boolean;
+
+            /** FileOptions javaStringCheckUtf8. */
+            public javaStringCheckUtf8: boolean;
+
+            /** FileOptions optimizeFor. */
+            public optimizeFor: google.protobuf.FileOptions.OptimizeMode;
+
+            /** FileOptions goPackage. */
+            public goPackage: string;
+
+            /** FileOptions ccGenericServices. */
+            public ccGenericServices: boolean;
+
+            /** FileOptions javaGenericServices. */
+            public javaGenericServices: boolean;
+
+            /** FileOptions pyGenericServices. */
+            public pyGenericServices: boolean;
+
+            /** FileOptions deprecated. */
+            public deprecated: boolean;
+
+            /** FileOptions ccEnableArenas. */
+            public ccEnableArenas: boolean;
+
+            /** FileOptions objcClassPrefix. */
+            public objcClassPrefix: string;
+
+            /** FileOptions csharpNamespace. */
+            public csharpNamespace: string;
+
+            /** FileOptions uninterpretedOption. */
+            public uninterpretedOption: google.protobuf.IUninterpretedOption[];
+
+            /**
+             * Creates a new FileOptions instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns FileOptions instance
+             */
+            public static create(properties?: google.protobuf.IFileOptions): google.protobuf.FileOptions;
+
+            /**
+             * Encodes the specified FileOptions message. Does not implicitly {@link google.protobuf.FileOptions.verify|verify} messages.
+             * @param message FileOptions message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IFileOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified FileOptions message, length delimited. Does not implicitly {@link google.protobuf.FileOptions.verify|verify} messages.
+             * @param message FileOptions message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IFileOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a FileOptions message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns FileOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.FileOptions;
+
+            /**
+             * Decodes a FileOptions message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns FileOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.FileOptions;
+
+            /**
+             * Verifies a FileOptions message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a FileOptions message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns FileOptions
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.FileOptions;
+
+            /**
+             * Creates a plain object from a FileOptions message. Also converts values to other types if specified.
+             * @param message FileOptions
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.FileOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this FileOptions to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        namespace FileOptions {
+
+            /** OptimizeMode enum. */
+            enum OptimizeMode {
+                SPEED = 1,
+                CODE_SIZE = 2,
+                LITE_RUNTIME = 3
+            }
+        }
+
+        /** Properties of a MessageOptions. */
+        interface IMessageOptions {
+
+            /** MessageOptions messageSetWireFormat */
+            messageSetWireFormat?: boolean;
+
+            /** MessageOptions noStandardDescriptorAccessor */
+            noStandardDescriptorAccessor?: boolean;
+
+            /** MessageOptions deprecated */
+            deprecated?: boolean;
+
+            /** MessageOptions mapEntry */
+            mapEntry?: boolean;
+
+            /** MessageOptions uninterpretedOption */
+            uninterpretedOption?: google.protobuf.IUninterpretedOption[];
+        }
+
+        /** Represents a MessageOptions. */
+        class MessageOptions {
+
+            /**
+             * Constructs a new MessageOptions.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IMessageOptions);
+
+            /** MessageOptions messageSetWireFormat. */
+            public messageSetWireFormat: boolean;
+
+            /** MessageOptions noStandardDescriptorAccessor. */
+            public noStandardDescriptorAccessor: boolean;
+
+            /** MessageOptions deprecated. */
+            public deprecated: boolean;
+
+            /** MessageOptions mapEntry. */
+            public mapEntry: boolean;
+
+            /** MessageOptions uninterpretedOption. */
+            public uninterpretedOption: google.protobuf.IUninterpretedOption[];
+
+            /**
+             * Creates a new MessageOptions instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns MessageOptions instance
+             */
+            public static create(properties?: google.protobuf.IMessageOptions): google.protobuf.MessageOptions;
+
+            /**
+             * Encodes the specified MessageOptions message. Does not implicitly {@link google.protobuf.MessageOptions.verify|verify} messages.
+             * @param message MessageOptions message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IMessageOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified MessageOptions message, length delimited. Does not implicitly {@link google.protobuf.MessageOptions.verify|verify} messages.
+             * @param message MessageOptions message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IMessageOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a MessageOptions message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns MessageOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.MessageOptions;
+
+            /**
+             * Decodes a MessageOptions message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns MessageOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.MessageOptions;
+
+            /**
+             * Verifies a MessageOptions message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a MessageOptions message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns MessageOptions
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.MessageOptions;
+
+            /**
+             * Creates a plain object from a MessageOptions message. Also converts values to other types if specified.
+             * @param message MessageOptions
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.MessageOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this MessageOptions to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a FieldOptions. */
+        interface IFieldOptions {
+
+            /** FieldOptions ctype */
+            ctype?: google.protobuf.FieldOptions.CType;
+
+            /** FieldOptions packed */
+            packed?: boolean;
+
+            /** FieldOptions jstype */
+            jstype?: google.protobuf.FieldOptions.JSType;
+
+            /** FieldOptions lazy */
+            lazy?: boolean;
+
+            /** FieldOptions deprecated */
+            deprecated?: boolean;
+
+            /** FieldOptions weak */
+            weak?: boolean;
+
+            /** FieldOptions uninterpretedOption */
+            uninterpretedOption?: google.protobuf.IUninterpretedOption[];
+        }
+
+        /** Represents a FieldOptions. */
+        class FieldOptions {
+
+            /**
+             * Constructs a new FieldOptions.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IFieldOptions);
+
+            /** FieldOptions ctype. */
+            public ctype: google.protobuf.FieldOptions.CType;
+
+            /** FieldOptions packed. */
+            public packed: boolean;
+
+            /** FieldOptions jstype. */
+            public jstype: google.protobuf.FieldOptions.JSType;
+
+            /** FieldOptions lazy. */
+            public lazy: boolean;
+
+            /** FieldOptions deprecated. */
+            public deprecated: boolean;
+
+            /** FieldOptions weak. */
+            public weak: boolean;
+
+            /** FieldOptions uninterpretedOption. */
+            public uninterpretedOption: google.protobuf.IUninterpretedOption[];
+
+            /**
+             * Creates a new FieldOptions instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns FieldOptions instance
+             */
+            public static create(properties?: google.protobuf.IFieldOptions): google.protobuf.FieldOptions;
+
+            /**
+             * Encodes the specified FieldOptions message. Does not implicitly {@link google.protobuf.FieldOptions.verify|verify} messages.
+             * @param message FieldOptions message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IFieldOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified FieldOptions message, length delimited. Does not implicitly {@link google.protobuf.FieldOptions.verify|verify} messages.
+             * @param message FieldOptions message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IFieldOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a FieldOptions message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns FieldOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.FieldOptions;
+
+            /**
+             * Decodes a FieldOptions message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns FieldOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.FieldOptions;
+
+            /**
+             * Verifies a FieldOptions message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a FieldOptions message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns FieldOptions
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.FieldOptions;
+
+            /**
+             * Creates a plain object from a FieldOptions message. Also converts values to other types if specified.
+             * @param message FieldOptions
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.FieldOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this FieldOptions to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        namespace FieldOptions {
+
+            /** CType enum. */
+            enum CType {
+                STRING = 0,
+                CORD = 1,
+                STRING_PIECE = 2
+            }
+
+            /** JSType enum. */
+            enum JSType {
+                JS_NORMAL = 0,
+                JS_STRING = 1,
+                JS_NUMBER = 2
+            }
+        }
+
+        /** Properties of an OneofOptions. */
+        interface IOneofOptions {
+
+            /** OneofOptions uninterpretedOption */
+            uninterpretedOption?: google.protobuf.IUninterpretedOption[];
+        }
+
+        /** Represents an OneofOptions. */
+        class OneofOptions {
+
+            /**
+             * Constructs a new OneofOptions.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IOneofOptions);
+
+            /** OneofOptions uninterpretedOption. */
+            public uninterpretedOption: google.protobuf.IUninterpretedOption[];
+
+            /**
+             * Creates a new OneofOptions instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns OneofOptions instance
+             */
+            public static create(properties?: google.protobuf.IOneofOptions): google.protobuf.OneofOptions;
+
+            /**
+             * Encodes the specified OneofOptions message. Does not implicitly {@link google.protobuf.OneofOptions.verify|verify} messages.
+             * @param message OneofOptions message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IOneofOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified OneofOptions message, length delimited. Does not implicitly {@link google.protobuf.OneofOptions.verify|verify} messages.
+             * @param message OneofOptions message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IOneofOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes an OneofOptions message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns OneofOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.OneofOptions;
+
+            /**
+             * Decodes an OneofOptions message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns OneofOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.OneofOptions;
+
+            /**
+             * Verifies an OneofOptions message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates an OneofOptions message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns OneofOptions
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.OneofOptions;
+
+            /**
+             * Creates a plain object from an OneofOptions message. Also converts values to other types if specified.
+             * @param message OneofOptions
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.OneofOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this OneofOptions to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of an EnumOptions. */
+        interface IEnumOptions {
+
+            /** EnumOptions allowAlias */
+            allowAlias?: boolean;
+
+            /** EnumOptions deprecated */
+            deprecated?: boolean;
+
+            /** EnumOptions uninterpretedOption */
+            uninterpretedOption?: google.protobuf.IUninterpretedOption[];
+        }
+
+        /** Represents an EnumOptions. */
+        class EnumOptions {
+
+            /**
+             * Constructs a new EnumOptions.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IEnumOptions);
+
+            /** EnumOptions allowAlias. */
+            public allowAlias: boolean;
+
+            /** EnumOptions deprecated. */
+            public deprecated: boolean;
+
+            /** EnumOptions uninterpretedOption. */
+            public uninterpretedOption: google.protobuf.IUninterpretedOption[];
+
+            /**
+             * Creates a new EnumOptions instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns EnumOptions instance
+             */
+            public static create(properties?: google.protobuf.IEnumOptions): google.protobuf.EnumOptions;
+
+            /**
+             * Encodes the specified EnumOptions message. Does not implicitly {@link google.protobuf.EnumOptions.verify|verify} messages.
+             * @param message EnumOptions message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IEnumOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified EnumOptions message, length delimited. Does not implicitly {@link google.protobuf.EnumOptions.verify|verify} messages.
+             * @param message EnumOptions message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IEnumOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes an EnumOptions message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns EnumOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.EnumOptions;
+
+            /**
+             * Decodes an EnumOptions message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns EnumOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.EnumOptions;
+
+            /**
+             * Verifies an EnumOptions message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates an EnumOptions message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns EnumOptions
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.EnumOptions;
+
+            /**
+             * Creates a plain object from an EnumOptions message. Also converts values to other types if specified.
+             * @param message EnumOptions
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.EnumOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this EnumOptions to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of an EnumValueOptions. */
+        interface IEnumValueOptions {
+
+            /** EnumValueOptions deprecated */
+            deprecated?: boolean;
+
+            /** EnumValueOptions uninterpretedOption */
+            uninterpretedOption?: google.protobuf.IUninterpretedOption[];
+        }
+
+        /** Represents an EnumValueOptions. */
+        class EnumValueOptions {
+
+            /**
+             * Constructs a new EnumValueOptions.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IEnumValueOptions);
+
+            /** EnumValueOptions deprecated. */
+            public deprecated: boolean;
+
+            /** EnumValueOptions uninterpretedOption. */
+            public uninterpretedOption: google.protobuf.IUninterpretedOption[];
+
+            /**
+             * Creates a new EnumValueOptions instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns EnumValueOptions instance
+             */
+            public static create(properties?: google.protobuf.IEnumValueOptions): google.protobuf.EnumValueOptions;
+
+            /**
+             * Encodes the specified EnumValueOptions message. Does not implicitly {@link google.protobuf.EnumValueOptions.verify|verify} messages.
+             * @param message EnumValueOptions message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IEnumValueOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified EnumValueOptions message, length delimited. Does not implicitly {@link google.protobuf.EnumValueOptions.verify|verify} messages.
+             * @param message EnumValueOptions message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IEnumValueOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes an EnumValueOptions message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns EnumValueOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.EnumValueOptions;
+
+            /**
+             * Decodes an EnumValueOptions message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns EnumValueOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.EnumValueOptions;
+
+            /**
+             * Verifies an EnumValueOptions message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates an EnumValueOptions message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns EnumValueOptions
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.EnumValueOptions;
+
+            /**
+             * Creates a plain object from an EnumValueOptions message. Also converts values to other types if specified.
+             * @param message EnumValueOptions
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.EnumValueOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this EnumValueOptions to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a ServiceOptions. */
+        interface IServiceOptions {
+
+            /** ServiceOptions deprecated */
+            deprecated?: boolean;
+
+            /** ServiceOptions uninterpretedOption */
+            uninterpretedOption?: google.protobuf.IUninterpretedOption[];
+        }
+
+        /** Represents a ServiceOptions. */
+        class ServiceOptions {
+
+            /**
+             * Constructs a new ServiceOptions.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IServiceOptions);
+
+            /** ServiceOptions deprecated. */
+            public deprecated: boolean;
+
+            /** ServiceOptions uninterpretedOption. */
+            public uninterpretedOption: google.protobuf.IUninterpretedOption[];
+
+            /**
+             * Creates a new ServiceOptions instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns ServiceOptions instance
+             */
+            public static create(properties?: google.protobuf.IServiceOptions): google.protobuf.ServiceOptions;
+
+            /**
+             * Encodes the specified ServiceOptions message. Does not implicitly {@link google.protobuf.ServiceOptions.verify|verify} messages.
+             * @param message ServiceOptions message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IServiceOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified ServiceOptions message, length delimited. Does not implicitly {@link google.protobuf.ServiceOptions.verify|verify} messages.
+             * @param message ServiceOptions message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IServiceOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a ServiceOptions message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns ServiceOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.ServiceOptions;
+
+            /**
+             * Decodes a ServiceOptions message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns ServiceOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.ServiceOptions;
+
+            /**
+             * Verifies a ServiceOptions message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a ServiceOptions message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns ServiceOptions
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.ServiceOptions;
+
+            /**
+             * Creates a plain object from a ServiceOptions message. Also converts values to other types if specified.
+             * @param message ServiceOptions
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.ServiceOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this ServiceOptions to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a MethodOptions. */
+        interface IMethodOptions {
+
+            /** MethodOptions deprecated */
+            deprecated?: boolean;
+
+            /** MethodOptions uninterpretedOption */
+            uninterpretedOption?: google.protobuf.IUninterpretedOption[];
+
+            /** MethodOptions .google.api.http */
+            ".google.api.http"?: google.api.IHttpRule;
+        }
+
+        /** Represents a MethodOptions. */
+        class MethodOptions {
+
+            /**
+             * Constructs a new MethodOptions.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IMethodOptions);
+
+            /** MethodOptions deprecated. */
+            public deprecated: boolean;
+
+            /** MethodOptions uninterpretedOption. */
+            public uninterpretedOption: google.protobuf.IUninterpretedOption[];
+
+            /**
+             * Creates a new MethodOptions instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns MethodOptions instance
+             */
+            public static create(properties?: google.protobuf.IMethodOptions): google.protobuf.MethodOptions;
+
+            /**
+             * Encodes the specified MethodOptions message. Does not implicitly {@link google.protobuf.MethodOptions.verify|verify} messages.
+             * @param message MethodOptions message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IMethodOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified MethodOptions message, length delimited. Does not implicitly {@link google.protobuf.MethodOptions.verify|verify} messages.
+             * @param message MethodOptions message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IMethodOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a MethodOptions message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns MethodOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.MethodOptions;
+
+            /**
+             * Decodes a MethodOptions message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns MethodOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.MethodOptions;
+
+            /**
+             * Verifies a MethodOptions message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a MethodOptions message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns MethodOptions
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.MethodOptions;
+
+            /**
+             * Creates a plain object from a MethodOptions message. Also converts values to other types if specified.
+             * @param message MethodOptions
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.MethodOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this MethodOptions to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of an UninterpretedOption. */
+        interface IUninterpretedOption {
+
+            /** UninterpretedOption name */
+            name?: google.protobuf.UninterpretedOption.INamePart[];
+
+            /** UninterpretedOption identifierValue */
+            identifierValue?: string;
+
+            /** UninterpretedOption positiveIntValue */
+            positiveIntValue?: (number|Long);
+
+            /** UninterpretedOption negativeIntValue */
+            negativeIntValue?: (number|Long);
+
+            /** UninterpretedOption doubleValue */
+            doubleValue?: number;
+
+            /** UninterpretedOption stringValue */
+            stringValue?: Uint8Array;
+
+            /** UninterpretedOption aggregateValue */
+            aggregateValue?: string;
+        }
+
+        /** Represents an UninterpretedOption. */
+        class UninterpretedOption {
+
+            /**
+             * Constructs a new UninterpretedOption.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IUninterpretedOption);
+
+            /** UninterpretedOption name. */
+            public name: google.protobuf.UninterpretedOption.INamePart[];
+
+            /** UninterpretedOption identifierValue. */
+            public identifierValue: string;
+
+            /** UninterpretedOption positiveIntValue. */
+            public positiveIntValue: (number|Long);
+
+            /** UninterpretedOption negativeIntValue. */
+            public negativeIntValue: (number|Long);
+
+            /** UninterpretedOption doubleValue. */
+            public doubleValue: number;
+
+            /** UninterpretedOption stringValue. */
+            public stringValue: Uint8Array;
+
+            /** UninterpretedOption aggregateValue. */
+            public aggregateValue: string;
+
+            /**
+             * Creates a new UninterpretedOption instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns UninterpretedOption instance
+             */
+            public static create(properties?: google.protobuf.IUninterpretedOption): google.protobuf.UninterpretedOption;
+
+            /**
+             * Encodes the specified UninterpretedOption message. Does not implicitly {@link google.protobuf.UninterpretedOption.verify|verify} messages.
+             * @param message UninterpretedOption message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IUninterpretedOption, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified UninterpretedOption message, length delimited. Does not implicitly {@link google.protobuf.UninterpretedOption.verify|verify} messages.
+             * @param message UninterpretedOption message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IUninterpretedOption, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes an UninterpretedOption message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns UninterpretedOption
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.UninterpretedOption;
+
+            /**
+             * Decodes an UninterpretedOption message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns UninterpretedOption
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.UninterpretedOption;
+
+            /**
+             * Verifies an UninterpretedOption message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates an UninterpretedOption message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns UninterpretedOption
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.UninterpretedOption;
+
+            /**
+             * Creates a plain object from an UninterpretedOption message. Also converts values to other types if specified.
+             * @param message UninterpretedOption
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.UninterpretedOption, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this UninterpretedOption to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        namespace UninterpretedOption {
+
+            /** Properties of a NamePart. */
+            interface INamePart {
+
+                /** NamePart namePart */
+                namePart: string;
+
+                /** NamePart isExtension */
+                isExtension: boolean;
+            }
+
+            /** Represents a NamePart. */
+            class NamePart {
+
+                /**
+                 * Constructs a new NamePart.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.protobuf.UninterpretedOption.INamePart);
+
+                /** NamePart namePart. */
+                public namePart: string;
+
+                /** NamePart isExtension. */
+                public isExtension: boolean;
+
+                /**
+                 * Creates a new NamePart instance using the specified properties.
+                 * @param [properties] Properties to set
+                 * @returns NamePart instance
+                 */
+                public static create(properties?: google.protobuf.UninterpretedOption.INamePart): google.protobuf.UninterpretedOption.NamePart;
+
+                /**
+                 * Encodes the specified NamePart message. Does not implicitly {@link google.protobuf.UninterpretedOption.NamePart.verify|verify} messages.
+                 * @param message NamePart message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encode(message: google.protobuf.UninterpretedOption.INamePart, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Encodes the specified NamePart message, length delimited. Does not implicitly {@link google.protobuf.UninterpretedOption.NamePart.verify|verify} messages.
+                 * @param message NamePart message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encodeDelimited(message: google.protobuf.UninterpretedOption.INamePart, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Decodes a NamePart message from the specified reader or buffer.
+                 * @param reader Reader or buffer to decode from
+                 * @param [length] Message length if known beforehand
+                 * @returns NamePart
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.UninterpretedOption.NamePart;
+
+                /**
+                 * Decodes a NamePart message from the specified reader or buffer, length delimited.
+                 * @param reader Reader or buffer to decode from
+                 * @returns NamePart
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.UninterpretedOption.NamePart;
+
+                /**
+                 * Verifies a NamePart message.
+                 * @param message Plain object to verify
+                 * @returns `null` if valid, otherwise the reason why it is not
+                 */
+                public static verify(message: { [k: string]: any }): (string|null);
+
+                /**
+                 * Creates a NamePart message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns NamePart
+                 */
+                public static fromObject(object: { [k: string]: any }): google.protobuf.UninterpretedOption.NamePart;
+
+                /**
+                 * Creates a plain object from a NamePart message. Also converts values to other types if specified.
+                 * @param message NamePart
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: google.protobuf.UninterpretedOption.NamePart, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this NamePart to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
+        }
+
+        /** Properties of a SourceCodeInfo. */
+        interface ISourceCodeInfo {
+
+            /** SourceCodeInfo location */
+            location?: google.protobuf.SourceCodeInfo.ILocation[];
+        }
+
+        /** Represents a SourceCodeInfo. */
+        class SourceCodeInfo {
+
+            /**
+             * Constructs a new SourceCodeInfo.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.ISourceCodeInfo);
+
+            /** SourceCodeInfo location. */
+            public location: google.protobuf.SourceCodeInfo.ILocation[];
+
+            /**
+             * Creates a new SourceCodeInfo instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns SourceCodeInfo instance
+             */
+            public static create(properties?: google.protobuf.ISourceCodeInfo): google.protobuf.SourceCodeInfo;
+
+            /**
+             * Encodes the specified SourceCodeInfo message. Does not implicitly {@link google.protobuf.SourceCodeInfo.verify|verify} messages.
+             * @param message SourceCodeInfo message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.ISourceCodeInfo, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified SourceCodeInfo message, length delimited. Does not implicitly {@link google.protobuf.SourceCodeInfo.verify|verify} messages.
+             * @param message SourceCodeInfo message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.ISourceCodeInfo, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a SourceCodeInfo message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns SourceCodeInfo
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.SourceCodeInfo;
+
+            /**
+             * Decodes a SourceCodeInfo message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns SourceCodeInfo
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.SourceCodeInfo;
+
+            /**
+             * Verifies a SourceCodeInfo message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a SourceCodeInfo message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns SourceCodeInfo
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.SourceCodeInfo;
+
+            /**
+             * Creates a plain object from a SourceCodeInfo message. Also converts values to other types if specified.
+             * @param message SourceCodeInfo
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.SourceCodeInfo, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this SourceCodeInfo to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        namespace SourceCodeInfo {
+
+            /** Properties of a Location. */
+            interface ILocation {
+
+                /** Location path */
+                path?: number[];
+
+                /** Location span */
+                span?: number[];
+
+                /** Location leadingComments */
+                leadingComments?: string;
+
+                /** Location trailingComments */
+                trailingComments?: string;
+
+                /** Location leadingDetachedComments */
+                leadingDetachedComments?: string[];
+            }
+
+            /** Represents a Location. */
+            class Location {
+
+                /**
+                 * Constructs a new Location.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.protobuf.SourceCodeInfo.ILocation);
+
+                /** Location path. */
+                public path: number[];
+
+                /** Location span. */
+                public span: number[];
+
+                /** Location leadingComments. */
+                public leadingComments: string;
+
+                /** Location trailingComments. */
+                public trailingComments: string;
+
+                /** Location leadingDetachedComments. */
+                public leadingDetachedComments: string[];
+
+                /**
+                 * Creates a new Location instance using the specified properties.
+                 * @param [properties] Properties to set
+                 * @returns Location instance
+                 */
+                public static create(properties?: google.protobuf.SourceCodeInfo.ILocation): google.protobuf.SourceCodeInfo.Location;
+
+                /**
+                 * Encodes the specified Location message. Does not implicitly {@link google.protobuf.SourceCodeInfo.Location.verify|verify} messages.
+                 * @param message Location message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encode(message: google.protobuf.SourceCodeInfo.ILocation, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Encodes the specified Location message, length delimited. Does not implicitly {@link google.protobuf.SourceCodeInfo.Location.verify|verify} messages.
+                 * @param message Location message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encodeDelimited(message: google.protobuf.SourceCodeInfo.ILocation, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Decodes a Location message from the specified reader or buffer.
+                 * @param reader Reader or buffer to decode from
+                 * @param [length] Message length if known beforehand
+                 * @returns Location
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.SourceCodeInfo.Location;
+
+                /**
+                 * Decodes a Location message from the specified reader or buffer, length delimited.
+                 * @param reader Reader or buffer to decode from
+                 * @returns Location
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.SourceCodeInfo.Location;
+
+                /**
+                 * Verifies a Location message.
+                 * @param message Plain object to verify
+                 * @returns `null` if valid, otherwise the reason why it is not
+                 */
+                public static verify(message: { [k: string]: any }): (string|null);
+
+                /**
+                 * Creates a Location message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns Location
+                 */
+                public static fromObject(object: { [k: string]: any }): google.protobuf.SourceCodeInfo.Location;
+
+                /**
+                 * Creates a plain object from a Location message. Also converts values to other types if specified.
+                 * @param message Location
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: google.protobuf.SourceCodeInfo.Location, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this Location to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
+        }
+
+        /** Properties of a GeneratedCodeInfo. */
+        interface IGeneratedCodeInfo {
+
+            /** GeneratedCodeInfo annotation */
+            annotation?: google.protobuf.GeneratedCodeInfo.IAnnotation[];
+        }
+
+        /** Represents a GeneratedCodeInfo. */
+        class GeneratedCodeInfo {
+
+            /**
+             * Constructs a new GeneratedCodeInfo.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IGeneratedCodeInfo);
+
+            /** GeneratedCodeInfo annotation. */
+            public annotation: google.protobuf.GeneratedCodeInfo.IAnnotation[];
+
+            /**
+             * Creates a new GeneratedCodeInfo instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns GeneratedCodeInfo instance
+             */
+            public static create(properties?: google.protobuf.IGeneratedCodeInfo): google.protobuf.GeneratedCodeInfo;
+
+            /**
+             * Encodes the specified GeneratedCodeInfo message. Does not implicitly {@link google.protobuf.GeneratedCodeInfo.verify|verify} messages.
+             * @param message GeneratedCodeInfo message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IGeneratedCodeInfo, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified GeneratedCodeInfo message, length delimited. Does not implicitly {@link google.protobuf.GeneratedCodeInfo.verify|verify} messages.
+             * @param message GeneratedCodeInfo message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IGeneratedCodeInfo, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a GeneratedCodeInfo message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns GeneratedCodeInfo
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.GeneratedCodeInfo;
+
+            /**
+             * Decodes a GeneratedCodeInfo message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns GeneratedCodeInfo
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.GeneratedCodeInfo;
+
+            /**
+             * Verifies a GeneratedCodeInfo message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a GeneratedCodeInfo message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns GeneratedCodeInfo
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.GeneratedCodeInfo;
+
+            /**
+             * Creates a plain object from a GeneratedCodeInfo message. Also converts values to other types if specified.
+             * @param message GeneratedCodeInfo
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.GeneratedCodeInfo, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this GeneratedCodeInfo to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        namespace GeneratedCodeInfo {
+
+            /** Properties of an Annotation. */
+            interface IAnnotation {
+
+                /** Annotation path */
+                path?: number[];
+
+                /** Annotation sourceFile */
+                sourceFile?: string;
+
+                /** Annotation begin */
+                begin?: number;
+
+                /** Annotation end */
+                end?: number;
+            }
+
+            /** Represents an Annotation. */
+            class Annotation {
+
+                /**
+                 * Constructs a new Annotation.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.protobuf.GeneratedCodeInfo.IAnnotation);
+
+                /** Annotation path. */
+                public path: number[];
+
+                /** Annotation sourceFile. */
+                public sourceFile: string;
+
+                /** Annotation begin. */
+                public begin: number;
+
+                /** Annotation end. */
+                public end: number;
+
+                /**
+                 * Creates a new Annotation instance using the specified properties.
+                 * @param [properties] Properties to set
+                 * @returns Annotation instance
+                 */
+                public static create(properties?: google.protobuf.GeneratedCodeInfo.IAnnotation): google.protobuf.GeneratedCodeInfo.Annotation;
+
+                /**
+                 * Encodes the specified Annotation message. Does not implicitly {@link google.protobuf.GeneratedCodeInfo.Annotation.verify|verify} messages.
+                 * @param message Annotation message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encode(message: google.protobuf.GeneratedCodeInfo.IAnnotation, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Encodes the specified Annotation message, length delimited. Does not implicitly {@link google.protobuf.GeneratedCodeInfo.Annotation.verify|verify} messages.
+                 * @param message Annotation message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encodeDelimited(message: google.protobuf.GeneratedCodeInfo.IAnnotation, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Decodes an Annotation message from the specified reader or buffer.
+                 * @param reader Reader or buffer to decode from
+                 * @param [length] Message length if known beforehand
+                 * @returns Annotation
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.GeneratedCodeInfo.Annotation;
+
+                /**
+                 * Decodes an Annotation message from the specified reader or buffer, length delimited.
+                 * @param reader Reader or buffer to decode from
+                 * @returns Annotation
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.GeneratedCodeInfo.Annotation;
+
+                /**
+                 * Verifies an Annotation message.
+                 * @param message Plain object to verify
+                 * @returns `null` if valid, otherwise the reason why it is not
+                 */
+                public static verify(message: { [k: string]: any }): (string|null);
+
+                /**
+                 * Creates an Annotation message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns Annotation
+                 */
+                public static fromObject(object: { [k: string]: any }): google.protobuf.GeneratedCodeInfo.Annotation;
+
+                /**
+                 * Creates a plain object from an Annotation message. Also converts values to other types if specified.
+                 * @param message Annotation
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: google.protobuf.GeneratedCodeInfo.Annotation, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this Annotation to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
+        }
+
+        /** Properties of a Duration. */
+        interface IDuration {
+
+            /** Duration seconds */
+            seconds?: (number|Long);
+
+            /** Duration nanos */
+            nanos?: number;
+        }
+
+        /** Represents a Duration. */
+        class Duration {
+
+            /**
+             * Constructs a new Duration.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IDuration);
+
+            /** Duration seconds. */
+            public seconds: (number|Long);
+
+            /** Duration nanos. */
+            public nanos: number;
+
+            /**
+             * Creates a new Duration instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns Duration instance
+             */
+            public static create(properties?: google.protobuf.IDuration): google.protobuf.Duration;
+
+            /**
+             * Encodes the specified Duration message. Does not implicitly {@link google.protobuf.Duration.verify|verify} messages.
+             * @param message Duration message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IDuration, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified Duration message, length delimited. Does not implicitly {@link google.protobuf.Duration.verify|verify} messages.
+             * @param message Duration message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IDuration, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a Duration message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns Duration
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.Duration;
+
+            /**
+             * Decodes a Duration message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns Duration
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.Duration;
+
+            /**
+             * Verifies a Duration message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a Duration message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns Duration
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.Duration;
+
+            /**
+             * Creates a plain object from a Duration message. Also converts values to other types if specified.
+             * @param message Duration
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.Duration, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this Duration to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a Timestamp. */
+        interface ITimestamp {
+
+            /** Timestamp seconds */
+            seconds?: (number|Long);
+
+            /** Timestamp nanos */
+            nanos?: number;
+        }
+
+        /** Represents a Timestamp. */
+        class Timestamp {
+
+            /**
+             * Constructs a new Timestamp.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.ITimestamp);
+
+            /** Timestamp seconds. */
+            public seconds: (number|Long);
+
+            /** Timestamp nanos. */
+            public nanos: number;
+
+            /**
+             * Creates a new Timestamp instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns Timestamp instance
+             */
+            public static create(properties?: google.protobuf.ITimestamp): google.protobuf.Timestamp;
+
+            /**
+             * Encodes the specified Timestamp message. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
+             * @param message Timestamp message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.ITimestamp, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified Timestamp message, length delimited. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
+             * @param message Timestamp message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.ITimestamp, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a Timestamp message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns Timestamp
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.Timestamp;
+
+            /**
+             * Decodes a Timestamp message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns Timestamp
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.Timestamp;
+
+            /**
+             * Verifies a Timestamp message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a Timestamp message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns Timestamp
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.Timestamp;
+
+            /**
+             * Creates a plain object from a Timestamp message. Also converts values to other types if specified.
+             * @param message Timestamp
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.Timestamp, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this Timestamp to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+    }
+}

--- a/proto/profiler.js
+++ b/proto/profiler.js
@@ -1,0 +1,10254 @@
+/*eslint-disable block-scoped-var, no-redeclare, no-control-regex, no-prototype-builtins*/
+"use strict";
+
+var $protobuf = require("protobufjs/minimal");
+
+// Common aliases
+var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
+
+// Exported root namespace
+var $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
+
+$root.google = (function() {
+
+    /**
+     * Namespace google.
+     * @exports google
+     * @namespace
+     */
+    var google = {};
+
+    google.devtools = (function() {
+
+        /**
+         * Namespace devtools.
+         * @memberof google
+         * @namespace
+         */
+        var devtools = {};
+
+        devtools.cloudprofiler = (function() {
+
+            /**
+             * Namespace cloudprofiler.
+             * @memberof google.devtools
+             * @namespace
+             */
+            var cloudprofiler = {};
+
+            cloudprofiler.v2 = (function() {
+
+                /**
+                 * Namespace v2.
+                 * @memberof google.devtools.cloudprofiler
+                 * @namespace
+                 */
+                var v2 = {};
+
+                v2.ProfilerService = (function() {
+
+                    /**
+                     * Constructs a new ProfilerService service.
+                     * @memberof google.devtools.cloudprofiler.v2
+                     * @classdesc Represents a ProfilerService
+                     * @extends $protobuf.rpc.Service
+                     * @constructor
+                     * @param {$protobuf.RPCImpl} rpcImpl RPC implementation
+                     * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
+                     * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
+                     */
+                    function ProfilerService(rpcImpl, requestDelimited, responseDelimited) {
+                        $protobuf.rpc.Service.call(this, rpcImpl, requestDelimited, responseDelimited);
+                    }
+
+                    (ProfilerService.prototype = Object.create($protobuf.rpc.Service.prototype)).constructor = ProfilerService;
+
+                    /**
+                     * Creates new ProfilerService service using the specified rpc implementation.
+                     * @function create
+                     * @memberof google.devtools.cloudprofiler.v2.ProfilerService
+                     * @static
+                     * @param {$protobuf.RPCImpl} rpcImpl RPC implementation
+                     * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
+                     * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
+                     * @returns {ProfilerService} RPC service. Useful where requests and/or responses are streamed.
+                     */
+                    ProfilerService.create = function create(rpcImpl, requestDelimited, responseDelimited) {
+                        return new this(rpcImpl, requestDelimited, responseDelimited);
+                    };
+
+                    /**
+                     * Callback as used by {@link google.devtools.cloudprofiler.v2.ProfilerService#createProfile}.
+                     * @memberof google.devtools.cloudprofiler.v2.ProfilerService
+                     * @typedef CreateProfileCallback
+                     * @type {function}
+                     * @param {Error|null} error Error, if any
+                     * @param {google.devtools.cloudprofiler.v2.Profile} [response] Profile
+                     */
+
+                    /**
+                     * Calls CreateProfile.
+                     * @function .createProfile
+                     * @memberof google.devtools.cloudprofiler.v2.ProfilerService
+                     * @instance
+                     * @param {google.devtools.cloudprofiler.v2.ICreateProfileRequest} request CreateProfileRequest message or plain object
+                     * @param {google.devtools.cloudprofiler.v2.ProfilerService.CreateProfileCallback} callback Node-style callback called with the error, if any, and Profile
+                     * @returns {undefined}
+                     * @variation 1
+                     */
+                    ProfilerService.prototype.createProfile = function createProfile(request, callback) {
+                        return this.rpcCall(createProfile, $root.google.devtools.cloudprofiler.v2.CreateProfileRequest, $root.google.devtools.cloudprofiler.v2.Profile, request, callback);
+                    };
+
+                    /**
+                     * Calls CreateProfile.
+                     * @function createProfile
+                     * @memberof google.devtools.cloudprofiler.v2.ProfilerService
+                     * @instance
+                     * @param {google.devtools.cloudprofiler.v2.ICreateProfileRequest} request CreateProfileRequest message or plain object
+                     * @returns {Promise<google.devtools.cloudprofiler.v2.Profile>} Promise
+                     * @variation 2
+                     */
+
+                    /**
+                     * Callback as used by {@link google.devtools.cloudprofiler.v2.ProfilerService#updateProfile}.
+                     * @memberof google.devtools.cloudprofiler.v2.ProfilerService
+                     * @typedef UpdateProfileCallback
+                     * @type {function}
+                     * @param {Error|null} error Error, if any
+                     * @param {google.devtools.cloudprofiler.v2.Profile} [response] Profile
+                     */
+
+                    /**
+                     * Calls UpdateProfile.
+                     * @function .updateProfile
+                     * @memberof google.devtools.cloudprofiler.v2.ProfilerService
+                     * @instance
+                     * @param {google.devtools.cloudprofiler.v2.IUpdateProfileRequest} request UpdateProfileRequest message or plain object
+                     * @param {google.devtools.cloudprofiler.v2.ProfilerService.UpdateProfileCallback} callback Node-style callback called with the error, if any, and Profile
+                     * @returns {undefined}
+                     * @variation 1
+                     */
+                    ProfilerService.prototype.updateProfile = function updateProfile(request, callback) {
+                        return this.rpcCall(updateProfile, $root.google.devtools.cloudprofiler.v2.UpdateProfileRequest, $root.google.devtools.cloudprofiler.v2.Profile, request, callback);
+                    };
+
+                    /**
+                     * Calls UpdateProfile.
+                     * @function updateProfile
+                     * @memberof google.devtools.cloudprofiler.v2.ProfilerService
+                     * @instance
+                     * @param {google.devtools.cloudprofiler.v2.IUpdateProfileRequest} request UpdateProfileRequest message or plain object
+                     * @returns {Promise<google.devtools.cloudprofiler.v2.Profile>} Promise
+                     * @variation 2
+                     */
+
+                    return ProfilerService;
+                })();
+
+                v2.CreateProfileRequest = (function() {
+
+                    /**
+                     * Properties of a CreateProfileRequest.
+                     * @memberof google.devtools.cloudprofiler.v2
+                     * @interface ICreateProfileRequest
+                     * @property {google.devtools.cloudprofiler.v2.IDeployment} [deployment] CreateProfileRequest deployment
+                     * @property {Array.<google.devtools.cloudprofiler.v2.ProfileType>} [profileType] CreateProfileRequest profileType
+                     * @property {google.devtools.cloudprofiler.v2.IProfile} [profile] CreateProfileRequest profile
+                     */
+
+                    /**
+                     * Constructs a new CreateProfileRequest.
+                     * @memberof google.devtools.cloudprofiler.v2
+                     * @classdesc Represents a CreateProfileRequest.
+                     * @constructor
+                     * @param {google.devtools.cloudprofiler.v2.ICreateProfileRequest=} [properties] Properties to set
+                     */
+                    function CreateProfileRequest(properties) {
+                        this.profileType = [];
+                        if (properties)
+                            for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                if (properties[keys[i]] != null)
+                                    this[keys[i]] = properties[keys[i]];
+                    }
+
+                    /**
+                     * CreateProfileRequest deployment.
+                     * @member {(google.devtools.cloudprofiler.v2.IDeployment|null|undefined)}deployment
+                     * @memberof google.devtools.cloudprofiler.v2.CreateProfileRequest
+                     * @instance
+                     */
+                    CreateProfileRequest.prototype.deployment = null;
+
+                    /**
+                     * CreateProfileRequest profileType.
+                     * @member {Array.<google.devtools.cloudprofiler.v2.ProfileType>}profileType
+                     * @memberof google.devtools.cloudprofiler.v2.CreateProfileRequest
+                     * @instance
+                     */
+                    CreateProfileRequest.prototype.profileType = $util.emptyArray;
+
+                    /**
+                     * CreateProfileRequest profile.
+                     * @member {(google.devtools.cloudprofiler.v2.IProfile|null|undefined)}profile
+                     * @memberof google.devtools.cloudprofiler.v2.CreateProfileRequest
+                     * @instance
+                     */
+                    CreateProfileRequest.prototype.profile = null;
+
+                    /**
+                     * Creates a new CreateProfileRequest instance using the specified properties.
+                     * @function create
+                     * @memberof google.devtools.cloudprofiler.v2.CreateProfileRequest
+                     * @static
+                     * @param {google.devtools.cloudprofiler.v2.ICreateProfileRequest=} [properties] Properties to set
+                     * @returns {google.devtools.cloudprofiler.v2.CreateProfileRequest} CreateProfileRequest instance
+                     */
+                    CreateProfileRequest.create = function create(properties) {
+                        return new CreateProfileRequest(properties);
+                    };
+
+                    /**
+                     * Encodes the specified CreateProfileRequest message. Does not implicitly {@link google.devtools.cloudprofiler.v2.CreateProfileRequest.verify|verify} messages.
+                     * @function encode
+                     * @memberof google.devtools.cloudprofiler.v2.CreateProfileRequest
+                     * @static
+                     * @param {google.devtools.cloudprofiler.v2.ICreateProfileRequest} message CreateProfileRequest message or plain object to encode
+                     * @param {$protobuf.Writer} [writer] Writer to encode to
+                     * @returns {$protobuf.Writer} Writer
+                     */
+                    CreateProfileRequest.encode = function encode(message, writer) {
+                        if (!writer)
+                            writer = $Writer.create();
+                        if (message.deployment != null && message.hasOwnProperty("deployment"))
+                            $root.google.devtools.cloudprofiler.v2.Deployment.encode(message.deployment, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                        if (message.profileType != null && message.profileType.length) {
+                            writer.uint32(/* id 2, wireType 2 =*/18).fork();
+                            for (var i = 0; i < message.profileType.length; ++i)
+                                writer.int32(message.profileType[i]);
+                            writer.ldelim();
+                        }
+                        if (message.profile != null && message.hasOwnProperty("profile"))
+                            $root.google.devtools.cloudprofiler.v2.Profile.encode(message.profile, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                        return writer;
+                    };
+
+                    /**
+                     * Encodes the specified CreateProfileRequest message, length delimited. Does not implicitly {@link google.devtools.cloudprofiler.v2.CreateProfileRequest.verify|verify} messages.
+                     * @function encodeDelimited
+                     * @memberof google.devtools.cloudprofiler.v2.CreateProfileRequest
+                     * @static
+                     * @param {google.devtools.cloudprofiler.v2.ICreateProfileRequest} message CreateProfileRequest message or plain object to encode
+                     * @param {$protobuf.Writer} [writer] Writer to encode to
+                     * @returns {$protobuf.Writer} Writer
+                     */
+                    CreateProfileRequest.encodeDelimited = function encodeDelimited(message, writer) {
+                        return this.encode(message, writer).ldelim();
+                    };
+
+                    /**
+                     * Decodes a CreateProfileRequest message from the specified reader or buffer.
+                     * @function decode
+                     * @memberof google.devtools.cloudprofiler.v2.CreateProfileRequest
+                     * @static
+                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                     * @param {number} [length] Message length if known beforehand
+                     * @returns {google.devtools.cloudprofiler.v2.CreateProfileRequest} CreateProfileRequest
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    CreateProfileRequest.decode = function decode(reader, length) {
+                        if (!(reader instanceof $Reader))
+                            reader = $Reader.create(reader);
+                        var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.devtools.cloudprofiler.v2.CreateProfileRequest();
+                        while (reader.pos < end) {
+                            var tag = reader.uint32();
+                            switch (tag >>> 3) {
+                            case 1:
+                                message.deployment = $root.google.devtools.cloudprofiler.v2.Deployment.decode(reader, reader.uint32());
+                                break;
+                            case 2:
+                                if (!(message.profileType && message.profileType.length))
+                                    message.profileType = [];
+                                if ((tag & 7) === 2) {
+                                    var end2 = reader.uint32() + reader.pos;
+                                    while (reader.pos < end2)
+                                        message.profileType.push(reader.int32());
+                                } else
+                                    message.profileType.push(reader.int32());
+                                break;
+                            case 3:
+                                message.profile = $root.google.devtools.cloudprofiler.v2.Profile.decode(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                            }
+                        }
+                        return message;
+                    };
+
+                    /**
+                     * Decodes a CreateProfileRequest message from the specified reader or buffer, length delimited.
+                     * @function decodeDelimited
+                     * @memberof google.devtools.cloudprofiler.v2.CreateProfileRequest
+                     * @static
+                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                     * @returns {google.devtools.cloudprofiler.v2.CreateProfileRequest} CreateProfileRequest
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    CreateProfileRequest.decodeDelimited = function decodeDelimited(reader) {
+                        if (!(reader instanceof $Reader))
+                            reader = new $Reader(reader);
+                        return this.decode(reader, reader.uint32());
+                    };
+
+                    /**
+                     * Verifies a CreateProfileRequest message.
+                     * @function verify
+                     * @memberof google.devtools.cloudprofiler.v2.CreateProfileRequest
+                     * @static
+                     * @param {Object.<string,*>} message Plain object to verify
+                     * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                     */
+                    CreateProfileRequest.verify = function verify(message) {
+                        if (typeof message !== "object" || message === null)
+                            return "object expected";
+                        if (message.deployment != null && message.hasOwnProperty("deployment")) {
+                            var error = $root.google.devtools.cloudprofiler.v2.Deployment.verify(message.deployment);
+                            if (error)
+                                return "deployment." + error;
+                        }
+                        if (message.profileType != null && message.hasOwnProperty("profileType")) {
+                            if (!Array.isArray(message.profileType))
+                                return "profileType: array expected";
+                            for (var i = 0; i < message.profileType.length; ++i)
+                                switch (message.profileType[i]) {
+                                default:
+                                    return "profileType: enum value[] expected";
+                                case 0:
+                                case 1:
+                                case 2:
+                                case 3:
+                                case 4:
+                                case 5:
+                                    break;
+                                }
+                        }
+                        if (message.profile != null && message.hasOwnProperty("profile")) {
+                            error = $root.google.devtools.cloudprofiler.v2.Profile.verify(message.profile);
+                            if (error)
+                                return "profile." + error;
+                        }
+                        return null;
+                    };
+
+                    /**
+                     * Creates a CreateProfileRequest message from a plain object. Also converts values to their respective internal types.
+                     * @function fromObject
+                     * @memberof google.devtools.cloudprofiler.v2.CreateProfileRequest
+                     * @static
+                     * @param {Object.<string,*>} object Plain object
+                     * @returns {google.devtools.cloudprofiler.v2.CreateProfileRequest} CreateProfileRequest
+                     */
+                    CreateProfileRequest.fromObject = function fromObject(object) {
+                        if (object instanceof $root.google.devtools.cloudprofiler.v2.CreateProfileRequest)
+                            return object;
+                        var message = new $root.google.devtools.cloudprofiler.v2.CreateProfileRequest();
+                        if (object.deployment != null) {
+                            if (typeof object.deployment !== "object")
+                                throw TypeError(".google.devtools.cloudprofiler.v2.CreateProfileRequest.deployment: object expected");
+                            message.deployment = $root.google.devtools.cloudprofiler.v2.Deployment.fromObject(object.deployment);
+                        }
+                        if (object.profileType) {
+                            if (!Array.isArray(object.profileType))
+                                throw TypeError(".google.devtools.cloudprofiler.v2.CreateProfileRequest.profileType: array expected");
+                            message.profileType = [];
+                            for (var i = 0; i < object.profileType.length; ++i)
+                                switch (object.profileType[i]) {
+                                default:
+                                case "PROFILE_TYPE_UNSPECIFIED":
+                                case 0:
+                                    message.profileType[i] = 0;
+                                    break;
+                                case "CPU":
+                                case 1:
+                                    message.profileType[i] = 1;
+                                    break;
+                                case "WALL":
+                                case 2:
+                                    message.profileType[i] = 2;
+                                    break;
+                                case "HEAP":
+                                case 3:
+                                    message.profileType[i] = 3;
+                                    break;
+                                case "THREADS":
+                                case 4:
+                                    message.profileType[i] = 4;
+                                    break;
+                                case "CONTENTION":
+                                case 5:
+                                    message.profileType[i] = 5;
+                                    break;
+                                }
+                        }
+                        if (object.profile != null) {
+                            if (typeof object.profile !== "object")
+                                throw TypeError(".google.devtools.cloudprofiler.v2.CreateProfileRequest.profile: object expected");
+                            message.profile = $root.google.devtools.cloudprofiler.v2.Profile.fromObject(object.profile);
+                        }
+                        return message;
+                    };
+
+                    /**
+                     * Creates a plain object from a CreateProfileRequest message. Also converts values to other types if specified.
+                     * @function toObject
+                     * @memberof google.devtools.cloudprofiler.v2.CreateProfileRequest
+                     * @static
+                     * @param {google.devtools.cloudprofiler.v2.CreateProfileRequest} message CreateProfileRequest
+                     * @param {$protobuf.IConversionOptions} [options] Conversion options
+                     * @returns {Object.<string,*>} Plain object
+                     */
+                    CreateProfileRequest.toObject = function toObject(message, options) {
+                        if (!options)
+                            options = {};
+                        var object = {};
+                        if (options.arrays || options.defaults)
+                            object.profileType = [];
+                        if (options.defaults) {
+                            object.deployment = null;
+                            object.profile = null;
+                        }
+                        if (message.deployment != null && message.hasOwnProperty("deployment"))
+                            object.deployment = $root.google.devtools.cloudprofiler.v2.Deployment.toObject(message.deployment, options);
+                        if (message.profileType && message.profileType.length) {
+                            object.profileType = [];
+                            for (var j = 0; j < message.profileType.length; ++j)
+                                object.profileType[j] = options.enums === String ? $root.google.devtools.cloudprofiler.v2.ProfileType[message.profileType[j]] : message.profileType[j];
+                        }
+                        if (message.profile != null && message.hasOwnProperty("profile"))
+                            object.profile = $root.google.devtools.cloudprofiler.v2.Profile.toObject(message.profile, options);
+                        return object;
+                    };
+
+                    /**
+                     * Converts this CreateProfileRequest to JSON.
+                     * @function toJSON
+                     * @memberof google.devtools.cloudprofiler.v2.CreateProfileRequest
+                     * @instance
+                     * @returns {Object.<string,*>} JSON object
+                     */
+                    CreateProfileRequest.prototype.toJSON = function toJSON() {
+                        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                    };
+
+                    return CreateProfileRequest;
+                })();
+
+                v2.UpdateProfileRequest = (function() {
+
+                    /**
+                     * Properties of an UpdateProfileRequest.
+                     * @memberof google.devtools.cloudprofiler.v2
+                     * @interface IUpdateProfileRequest
+                     * @property {google.devtools.cloudprofiler.v2.IProfile} [profile] UpdateProfileRequest profile
+                     */
+
+                    /**
+                     * Constructs a new UpdateProfileRequest.
+                     * @memberof google.devtools.cloudprofiler.v2
+                     * @classdesc Represents an UpdateProfileRequest.
+                     * @constructor
+                     * @param {google.devtools.cloudprofiler.v2.IUpdateProfileRequest=} [properties] Properties to set
+                     */
+                    function UpdateProfileRequest(properties) {
+                        if (properties)
+                            for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                if (properties[keys[i]] != null)
+                                    this[keys[i]] = properties[keys[i]];
+                    }
+
+                    /**
+                     * UpdateProfileRequest profile.
+                     * @member {(google.devtools.cloudprofiler.v2.IProfile|null|undefined)}profile
+                     * @memberof google.devtools.cloudprofiler.v2.UpdateProfileRequest
+                     * @instance
+                     */
+                    UpdateProfileRequest.prototype.profile = null;
+
+                    /**
+                     * Creates a new UpdateProfileRequest instance using the specified properties.
+                     * @function create
+                     * @memberof google.devtools.cloudprofiler.v2.UpdateProfileRequest
+                     * @static
+                     * @param {google.devtools.cloudprofiler.v2.IUpdateProfileRequest=} [properties] Properties to set
+                     * @returns {google.devtools.cloudprofiler.v2.UpdateProfileRequest} UpdateProfileRequest instance
+                     */
+                    UpdateProfileRequest.create = function create(properties) {
+                        return new UpdateProfileRequest(properties);
+                    };
+
+                    /**
+                     * Encodes the specified UpdateProfileRequest message. Does not implicitly {@link google.devtools.cloudprofiler.v2.UpdateProfileRequest.verify|verify} messages.
+                     * @function encode
+                     * @memberof google.devtools.cloudprofiler.v2.UpdateProfileRequest
+                     * @static
+                     * @param {google.devtools.cloudprofiler.v2.IUpdateProfileRequest} message UpdateProfileRequest message or plain object to encode
+                     * @param {$protobuf.Writer} [writer] Writer to encode to
+                     * @returns {$protobuf.Writer} Writer
+                     */
+                    UpdateProfileRequest.encode = function encode(message, writer) {
+                        if (!writer)
+                            writer = $Writer.create();
+                        if (message.profile != null && message.hasOwnProperty("profile"))
+                            $root.google.devtools.cloudprofiler.v2.Profile.encode(message.profile, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                        return writer;
+                    };
+
+                    /**
+                     * Encodes the specified UpdateProfileRequest message, length delimited. Does not implicitly {@link google.devtools.cloudprofiler.v2.UpdateProfileRequest.verify|verify} messages.
+                     * @function encodeDelimited
+                     * @memberof google.devtools.cloudprofiler.v2.UpdateProfileRequest
+                     * @static
+                     * @param {google.devtools.cloudprofiler.v2.IUpdateProfileRequest} message UpdateProfileRequest message or plain object to encode
+                     * @param {$protobuf.Writer} [writer] Writer to encode to
+                     * @returns {$protobuf.Writer} Writer
+                     */
+                    UpdateProfileRequest.encodeDelimited = function encodeDelimited(message, writer) {
+                        return this.encode(message, writer).ldelim();
+                    };
+
+                    /**
+                     * Decodes an UpdateProfileRequest message from the specified reader or buffer.
+                     * @function decode
+                     * @memberof google.devtools.cloudprofiler.v2.UpdateProfileRequest
+                     * @static
+                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                     * @param {number} [length] Message length if known beforehand
+                     * @returns {google.devtools.cloudprofiler.v2.UpdateProfileRequest} UpdateProfileRequest
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    UpdateProfileRequest.decode = function decode(reader, length) {
+                        if (!(reader instanceof $Reader))
+                            reader = $Reader.create(reader);
+                        var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.devtools.cloudprofiler.v2.UpdateProfileRequest();
+                        while (reader.pos < end) {
+                            var tag = reader.uint32();
+                            switch (tag >>> 3) {
+                            case 1:
+                                message.profile = $root.google.devtools.cloudprofiler.v2.Profile.decode(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                            }
+                        }
+                        return message;
+                    };
+
+                    /**
+                     * Decodes an UpdateProfileRequest message from the specified reader or buffer, length delimited.
+                     * @function decodeDelimited
+                     * @memberof google.devtools.cloudprofiler.v2.UpdateProfileRequest
+                     * @static
+                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                     * @returns {google.devtools.cloudprofiler.v2.UpdateProfileRequest} UpdateProfileRequest
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    UpdateProfileRequest.decodeDelimited = function decodeDelimited(reader) {
+                        if (!(reader instanceof $Reader))
+                            reader = new $Reader(reader);
+                        return this.decode(reader, reader.uint32());
+                    };
+
+                    /**
+                     * Verifies an UpdateProfileRequest message.
+                     * @function verify
+                     * @memberof google.devtools.cloudprofiler.v2.UpdateProfileRequest
+                     * @static
+                     * @param {Object.<string,*>} message Plain object to verify
+                     * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                     */
+                    UpdateProfileRequest.verify = function verify(message) {
+                        if (typeof message !== "object" || message === null)
+                            return "object expected";
+                        if (message.profile != null && message.hasOwnProperty("profile")) {
+                            var error = $root.google.devtools.cloudprofiler.v2.Profile.verify(message.profile);
+                            if (error)
+                                return "profile." + error;
+                        }
+                        return null;
+                    };
+
+                    /**
+                     * Creates an UpdateProfileRequest message from a plain object. Also converts values to their respective internal types.
+                     * @function fromObject
+                     * @memberof google.devtools.cloudprofiler.v2.UpdateProfileRequest
+                     * @static
+                     * @param {Object.<string,*>} object Plain object
+                     * @returns {google.devtools.cloudprofiler.v2.UpdateProfileRequest} UpdateProfileRequest
+                     */
+                    UpdateProfileRequest.fromObject = function fromObject(object) {
+                        if (object instanceof $root.google.devtools.cloudprofiler.v2.UpdateProfileRequest)
+                            return object;
+                        var message = new $root.google.devtools.cloudprofiler.v2.UpdateProfileRequest();
+                        if (object.profile != null) {
+                            if (typeof object.profile !== "object")
+                                throw TypeError(".google.devtools.cloudprofiler.v2.UpdateProfileRequest.profile: object expected");
+                            message.profile = $root.google.devtools.cloudprofiler.v2.Profile.fromObject(object.profile);
+                        }
+                        return message;
+                    };
+
+                    /**
+                     * Creates a plain object from an UpdateProfileRequest message. Also converts values to other types if specified.
+                     * @function toObject
+                     * @memberof google.devtools.cloudprofiler.v2.UpdateProfileRequest
+                     * @static
+                     * @param {google.devtools.cloudprofiler.v2.UpdateProfileRequest} message UpdateProfileRequest
+                     * @param {$protobuf.IConversionOptions} [options] Conversion options
+                     * @returns {Object.<string,*>} Plain object
+                     */
+                    UpdateProfileRequest.toObject = function toObject(message, options) {
+                        if (!options)
+                            options = {};
+                        var object = {};
+                        if (options.defaults)
+                            object.profile = null;
+                        if (message.profile != null && message.hasOwnProperty("profile"))
+                            object.profile = $root.google.devtools.cloudprofiler.v2.Profile.toObject(message.profile, options);
+                        return object;
+                    };
+
+                    /**
+                     * Converts this UpdateProfileRequest to JSON.
+                     * @function toJSON
+                     * @memberof google.devtools.cloudprofiler.v2.UpdateProfileRequest
+                     * @instance
+                     * @returns {Object.<string,*>} JSON object
+                     */
+                    UpdateProfileRequest.prototype.toJSON = function toJSON() {
+                        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                    };
+
+                    return UpdateProfileRequest;
+                })();
+
+                v2.Profile = (function() {
+
+                    /**
+                     * Properties of a Profile.
+                     * @memberof google.devtools.cloudprofiler.v2
+                     * @interface IProfile
+                     * @property {string} [name] Profile name
+                     * @property {google.devtools.cloudprofiler.v2.ProfileType} [profileType] Profile profileType
+                     * @property {google.devtools.cloudprofiler.v2.IDeployment} [deployment] Profile deployment
+                     * @property {google.protobuf.IDuration} [duration] Profile duration
+                     * @property {Uint8Array} [profileBytes] Profile profileBytes
+                     * @property {Object.<string,string>} [labels] Profile labels
+                     */
+
+                    /**
+                     * Constructs a new Profile.
+                     * @memberof google.devtools.cloudprofiler.v2
+                     * @classdesc Represents a Profile.
+                     * @constructor
+                     * @param {google.devtools.cloudprofiler.v2.IProfile=} [properties] Properties to set
+                     */
+                    function Profile(properties) {
+                        this.labels = {};
+                        if (properties)
+                            for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                if (properties[keys[i]] != null)
+                                    this[keys[i]] = properties[keys[i]];
+                    }
+
+                    /**
+                     * Profile name.
+                     * @member {string}name
+                     * @memberof google.devtools.cloudprofiler.v2.Profile
+                     * @instance
+                     */
+                    Profile.prototype.name = "";
+
+                    /**
+                     * Profile profileType.
+                     * @member {google.devtools.cloudprofiler.v2.ProfileType}profileType
+                     * @memberof google.devtools.cloudprofiler.v2.Profile
+                     * @instance
+                     */
+                    Profile.prototype.profileType = 0;
+
+                    /**
+                     * Profile deployment.
+                     * @member {(google.devtools.cloudprofiler.v2.IDeployment|null|undefined)}deployment
+                     * @memberof google.devtools.cloudprofiler.v2.Profile
+                     * @instance
+                     */
+                    Profile.prototype.deployment = null;
+
+                    /**
+                     * Profile duration.
+                     * @member {(google.protobuf.IDuration|null|undefined)}duration
+                     * @memberof google.devtools.cloudprofiler.v2.Profile
+                     * @instance
+                     */
+                    Profile.prototype.duration = null;
+
+                    /**
+                     * Profile profileBytes.
+                     * @member {Uint8Array}profileBytes
+                     * @memberof google.devtools.cloudprofiler.v2.Profile
+                     * @instance
+                     */
+                    Profile.prototype.profileBytes = $util.newBuffer([]);
+
+                    /**
+                     * Profile labels.
+                     * @member {Object.<string,string>}labels
+                     * @memberof google.devtools.cloudprofiler.v2.Profile
+                     * @instance
+                     */
+                    Profile.prototype.labels = $util.emptyObject;
+
+                    /**
+                     * Creates a new Profile instance using the specified properties.
+                     * @function create
+                     * @memberof google.devtools.cloudprofiler.v2.Profile
+                     * @static
+                     * @param {google.devtools.cloudprofiler.v2.IProfile=} [properties] Properties to set
+                     * @returns {google.devtools.cloudprofiler.v2.Profile} Profile instance
+                     */
+                    Profile.create = function create(properties) {
+                        return new Profile(properties);
+                    };
+
+                    /**
+                     * Encodes the specified Profile message. Does not implicitly {@link google.devtools.cloudprofiler.v2.Profile.verify|verify} messages.
+                     * @function encode
+                     * @memberof google.devtools.cloudprofiler.v2.Profile
+                     * @static
+                     * @param {google.devtools.cloudprofiler.v2.IProfile} message Profile message or plain object to encode
+                     * @param {$protobuf.Writer} [writer] Writer to encode to
+                     * @returns {$protobuf.Writer} Writer
+                     */
+                    Profile.encode = function encode(message, writer) {
+                        if (!writer)
+                            writer = $Writer.create();
+                        if (message.name != null && message.hasOwnProperty("name"))
+                            writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
+                        if (message.profileType != null && message.hasOwnProperty("profileType"))
+                            writer.uint32(/* id 2, wireType 0 =*/16).int32(message.profileType);
+                        if (message.deployment != null && message.hasOwnProperty("deployment"))
+                            $root.google.devtools.cloudprofiler.v2.Deployment.encode(message.deployment, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                        if (message.duration != null && message.hasOwnProperty("duration"))
+                            $root.google.protobuf.Duration.encode(message.duration, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                        if (message.profileBytes != null && message.hasOwnProperty("profileBytes"))
+                            writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.profileBytes);
+                        if (message.labels != null && message.hasOwnProperty("labels"))
+                            for (var keys = Object.keys(message.labels), i = 0; i < keys.length; ++i)
+                                writer.uint32(/* id 6, wireType 2 =*/50).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.labels[keys[i]]).ldelim();
+                        return writer;
+                    };
+
+                    /**
+                     * Encodes the specified Profile message, length delimited. Does not implicitly {@link google.devtools.cloudprofiler.v2.Profile.verify|verify} messages.
+                     * @function encodeDelimited
+                     * @memberof google.devtools.cloudprofiler.v2.Profile
+                     * @static
+                     * @param {google.devtools.cloudprofiler.v2.IProfile} message Profile message or plain object to encode
+                     * @param {$protobuf.Writer} [writer] Writer to encode to
+                     * @returns {$protobuf.Writer} Writer
+                     */
+                    Profile.encodeDelimited = function encodeDelimited(message, writer) {
+                        return this.encode(message, writer).ldelim();
+                    };
+
+                    /**
+                     * Decodes a Profile message from the specified reader or buffer.
+                     * @function decode
+                     * @memberof google.devtools.cloudprofiler.v2.Profile
+                     * @static
+                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                     * @param {number} [length] Message length if known beforehand
+                     * @returns {google.devtools.cloudprofiler.v2.Profile} Profile
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    Profile.decode = function decode(reader, length) {
+                        if (!(reader instanceof $Reader))
+                            reader = $Reader.create(reader);
+                        var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.devtools.cloudprofiler.v2.Profile(), key;
+                        while (reader.pos < end) {
+                            var tag = reader.uint32();
+                            switch (tag >>> 3) {
+                            case 1:
+                                message.name = reader.string();
+                                break;
+                            case 2:
+                                message.profileType = reader.int32();
+                                break;
+                            case 3:
+                                message.deployment = $root.google.devtools.cloudprofiler.v2.Deployment.decode(reader, reader.uint32());
+                                break;
+                            case 4:
+                                message.duration = $root.google.protobuf.Duration.decode(reader, reader.uint32());
+                                break;
+                            case 5:
+                                message.profileBytes = reader.bytes();
+                                break;
+                            case 6:
+                                reader.skip().pos++;
+                                if (message.labels === $util.emptyObject)
+                                    message.labels = {};
+                                key = reader.string();
+                                reader.pos++;
+                                message.labels[key] = reader.string();
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                            }
+                        }
+                        return message;
+                    };
+
+                    /**
+                     * Decodes a Profile message from the specified reader or buffer, length delimited.
+                     * @function decodeDelimited
+                     * @memberof google.devtools.cloudprofiler.v2.Profile
+                     * @static
+                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                     * @returns {google.devtools.cloudprofiler.v2.Profile} Profile
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    Profile.decodeDelimited = function decodeDelimited(reader) {
+                        if (!(reader instanceof $Reader))
+                            reader = new $Reader(reader);
+                        return this.decode(reader, reader.uint32());
+                    };
+
+                    /**
+                     * Verifies a Profile message.
+                     * @function verify
+                     * @memberof google.devtools.cloudprofiler.v2.Profile
+                     * @static
+                     * @param {Object.<string,*>} message Plain object to verify
+                     * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                     */
+                    Profile.verify = function verify(message) {
+                        if (typeof message !== "object" || message === null)
+                            return "object expected";
+                        if (message.name != null && message.hasOwnProperty("name"))
+                            if (!$util.isString(message.name))
+                                return "name: string expected";
+                        if (message.profileType != null && message.hasOwnProperty("profileType"))
+                            switch (message.profileType) {
+                            default:
+                                return "profileType: enum value expected";
+                            case 0:
+                            case 1:
+                            case 2:
+                            case 3:
+                            case 4:
+                            case 5:
+                                break;
+                            }
+                        if (message.deployment != null && message.hasOwnProperty("deployment")) {
+                            var error = $root.google.devtools.cloudprofiler.v2.Deployment.verify(message.deployment);
+                            if (error)
+                                return "deployment." + error;
+                        }
+                        if (message.duration != null && message.hasOwnProperty("duration")) {
+                            error = $root.google.protobuf.Duration.verify(message.duration);
+                            if (error)
+                                return "duration." + error;
+                        }
+                        if (message.profileBytes != null && message.hasOwnProperty("profileBytes"))
+                            if (!(message.profileBytes && typeof message.profileBytes.length === "number" || $util.isString(message.profileBytes)))
+                                return "profileBytes: buffer expected";
+                        if (message.labels != null && message.hasOwnProperty("labels")) {
+                            if (!$util.isObject(message.labels))
+                                return "labels: object expected";
+                            var key = Object.keys(message.labels);
+                            for (var i = 0; i < key.length; ++i)
+                                if (!$util.isString(message.labels[key[i]]))
+                                    return "labels: string{k:string} expected";
+                        }
+                        return null;
+                    };
+
+                    /**
+                     * Creates a Profile message from a plain object. Also converts values to their respective internal types.
+                     * @function fromObject
+                     * @memberof google.devtools.cloudprofiler.v2.Profile
+                     * @static
+                     * @param {Object.<string,*>} object Plain object
+                     * @returns {google.devtools.cloudprofiler.v2.Profile} Profile
+                     */
+                    Profile.fromObject = function fromObject(object) {
+                        if (object instanceof $root.google.devtools.cloudprofiler.v2.Profile)
+                            return object;
+                        var message = new $root.google.devtools.cloudprofiler.v2.Profile();
+                        if (object.name != null)
+                            message.name = String(object.name);
+                        switch (object.profileType) {
+                        case "PROFILE_TYPE_UNSPECIFIED":
+                        case 0:
+                            message.profileType = 0;
+                            break;
+                        case "CPU":
+                        case 1:
+                            message.profileType = 1;
+                            break;
+                        case "WALL":
+                        case 2:
+                            message.profileType = 2;
+                            break;
+                        case "HEAP":
+                        case 3:
+                            message.profileType = 3;
+                            break;
+                        case "THREADS":
+                        case 4:
+                            message.profileType = 4;
+                            break;
+                        case "CONTENTION":
+                        case 5:
+                            message.profileType = 5;
+                            break;
+                        }
+                        if (object.deployment != null) {
+                            if (typeof object.deployment !== "object")
+                                throw TypeError(".google.devtools.cloudprofiler.v2.Profile.deployment: object expected");
+                            message.deployment = $root.google.devtools.cloudprofiler.v2.Deployment.fromObject(object.deployment);
+                        }
+                        if (object.duration != null) {
+                            if (typeof object.duration !== "object")
+                                throw TypeError(".google.devtools.cloudprofiler.v2.Profile.duration: object expected");
+                            message.duration = $root.google.protobuf.Duration.fromObject(object.duration);
+                        }
+                        if (object.profileBytes != null)
+                            if (typeof object.profileBytes === "string")
+                                $util.base64.decode(object.profileBytes, message.profileBytes = $util.newBuffer($util.base64.length(object.profileBytes)), 0);
+                            else if (object.profileBytes.length)
+                                message.profileBytes = object.profileBytes;
+                        if (object.labels) {
+                            if (typeof object.labels !== "object")
+                                throw TypeError(".google.devtools.cloudprofiler.v2.Profile.labels: object expected");
+                            message.labels = {};
+                            for (var keys = Object.keys(object.labels), i = 0; i < keys.length; ++i)
+                                message.labels[keys[i]] = String(object.labels[keys[i]]);
+                        }
+                        return message;
+                    };
+
+                    /**
+                     * Creates a plain object from a Profile message. Also converts values to other types if specified.
+                     * @function toObject
+                     * @memberof google.devtools.cloudprofiler.v2.Profile
+                     * @static
+                     * @param {google.devtools.cloudprofiler.v2.Profile} message Profile
+                     * @param {$protobuf.IConversionOptions} [options] Conversion options
+                     * @returns {Object.<string,*>} Plain object
+                     */
+                    Profile.toObject = function toObject(message, options) {
+                        if (!options)
+                            options = {};
+                        var object = {};
+                        if (options.objects || options.defaults)
+                            object.labels = {};
+                        if (options.defaults) {
+                            object.name = "";
+                            object.profileType = options.enums === String ? "PROFILE_TYPE_UNSPECIFIED" : 0;
+                            object.deployment = null;
+                            object.duration = null;
+                            object.profileBytes = options.bytes === String ? "" : [];
+                        }
+                        if (message.name != null && message.hasOwnProperty("name"))
+                            object.name = message.name;
+                        if (message.profileType != null && message.hasOwnProperty("profileType"))
+                            object.profileType = options.enums === String ? $root.google.devtools.cloudprofiler.v2.ProfileType[message.profileType] : message.profileType;
+                        if (message.deployment != null && message.hasOwnProperty("deployment"))
+                            object.deployment = $root.google.devtools.cloudprofiler.v2.Deployment.toObject(message.deployment, options);
+                        if (message.duration != null && message.hasOwnProperty("duration"))
+                            object.duration = $root.google.protobuf.Duration.toObject(message.duration, options);
+                        if (message.profileBytes != null && message.hasOwnProperty("profileBytes"))
+                            object.profileBytes = options.bytes === String ? $util.base64.encode(message.profileBytes, 0, message.profileBytes.length) : options.bytes === Array ? Array.prototype.slice.call(message.profileBytes) : message.profileBytes;
+                        var keys2;
+                        if (message.labels && (keys2 = Object.keys(message.labels)).length) {
+                            object.labels = {};
+                            for (var j = 0; j < keys2.length; ++j)
+                                object.labels[keys2[j]] = message.labels[keys2[j]];
+                        }
+                        return object;
+                    };
+
+                    /**
+                     * Converts this Profile to JSON.
+                     * @function toJSON
+                     * @memberof google.devtools.cloudprofiler.v2.Profile
+                     * @instance
+                     * @returns {Object.<string,*>} JSON object
+                     */
+                    Profile.prototype.toJSON = function toJSON() {
+                        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                    };
+
+                    return Profile;
+                })();
+
+                v2.Deployment = (function() {
+
+                    /**
+                     * Properties of a Deployment.
+                     * @memberof google.devtools.cloudprofiler.v2
+                     * @interface IDeployment
+                     * @property {string} [projectId] Deployment projectId
+                     * @property {string} [target] Deployment target
+                     * @property {Object.<string,string>} [labels] Deployment labels
+                     */
+
+                    /**
+                     * Constructs a new Deployment.
+                     * @memberof google.devtools.cloudprofiler.v2
+                     * @classdesc Represents a Deployment.
+                     * @constructor
+                     * @param {google.devtools.cloudprofiler.v2.IDeployment=} [properties] Properties to set
+                     */
+                    function Deployment(properties) {
+                        this.labels = {};
+                        if (properties)
+                            for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                if (properties[keys[i]] != null)
+                                    this[keys[i]] = properties[keys[i]];
+                    }
+
+                    /**
+                     * Deployment projectId.
+                     * @member {string}projectId
+                     * @memberof google.devtools.cloudprofiler.v2.Deployment
+                     * @instance
+                     */
+                    Deployment.prototype.projectId = "";
+
+                    /**
+                     * Deployment target.
+                     * @member {string}target
+                     * @memberof google.devtools.cloudprofiler.v2.Deployment
+                     * @instance
+                     */
+                    Deployment.prototype.target = "";
+
+                    /**
+                     * Deployment labels.
+                     * @member {Object.<string,string>}labels
+                     * @memberof google.devtools.cloudprofiler.v2.Deployment
+                     * @instance
+                     */
+                    Deployment.prototype.labels = $util.emptyObject;
+
+                    /**
+                     * Creates a new Deployment instance using the specified properties.
+                     * @function create
+                     * @memberof google.devtools.cloudprofiler.v2.Deployment
+                     * @static
+                     * @param {google.devtools.cloudprofiler.v2.IDeployment=} [properties] Properties to set
+                     * @returns {google.devtools.cloudprofiler.v2.Deployment} Deployment instance
+                     */
+                    Deployment.create = function create(properties) {
+                        return new Deployment(properties);
+                    };
+
+                    /**
+                     * Encodes the specified Deployment message. Does not implicitly {@link google.devtools.cloudprofiler.v2.Deployment.verify|verify} messages.
+                     * @function encode
+                     * @memberof google.devtools.cloudprofiler.v2.Deployment
+                     * @static
+                     * @param {google.devtools.cloudprofiler.v2.IDeployment} message Deployment message or plain object to encode
+                     * @param {$protobuf.Writer} [writer] Writer to encode to
+                     * @returns {$protobuf.Writer} Writer
+                     */
+                    Deployment.encode = function encode(message, writer) {
+                        if (!writer)
+                            writer = $Writer.create();
+                        if (message.projectId != null && message.hasOwnProperty("projectId"))
+                            writer.uint32(/* id 1, wireType 2 =*/10).string(message.projectId);
+                        if (message.target != null && message.hasOwnProperty("target"))
+                            writer.uint32(/* id 2, wireType 2 =*/18).string(message.target);
+                        if (message.labels != null && message.hasOwnProperty("labels"))
+                            for (var keys = Object.keys(message.labels), i = 0; i < keys.length; ++i)
+                                writer.uint32(/* id 3, wireType 2 =*/26).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.labels[keys[i]]).ldelim();
+                        return writer;
+                    };
+
+                    /**
+                     * Encodes the specified Deployment message, length delimited. Does not implicitly {@link google.devtools.cloudprofiler.v2.Deployment.verify|verify} messages.
+                     * @function encodeDelimited
+                     * @memberof google.devtools.cloudprofiler.v2.Deployment
+                     * @static
+                     * @param {google.devtools.cloudprofiler.v2.IDeployment} message Deployment message or plain object to encode
+                     * @param {$protobuf.Writer} [writer] Writer to encode to
+                     * @returns {$protobuf.Writer} Writer
+                     */
+                    Deployment.encodeDelimited = function encodeDelimited(message, writer) {
+                        return this.encode(message, writer).ldelim();
+                    };
+
+                    /**
+                     * Decodes a Deployment message from the specified reader or buffer.
+                     * @function decode
+                     * @memberof google.devtools.cloudprofiler.v2.Deployment
+                     * @static
+                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                     * @param {number} [length] Message length if known beforehand
+                     * @returns {google.devtools.cloudprofiler.v2.Deployment} Deployment
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    Deployment.decode = function decode(reader, length) {
+                        if (!(reader instanceof $Reader))
+                            reader = $Reader.create(reader);
+                        var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.devtools.cloudprofiler.v2.Deployment(), key;
+                        while (reader.pos < end) {
+                            var tag = reader.uint32();
+                            switch (tag >>> 3) {
+                            case 1:
+                                message.projectId = reader.string();
+                                break;
+                            case 2:
+                                message.target = reader.string();
+                                break;
+                            case 3:
+                                reader.skip().pos++;
+                                if (message.labels === $util.emptyObject)
+                                    message.labels = {};
+                                key = reader.string();
+                                reader.pos++;
+                                message.labels[key] = reader.string();
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                            }
+                        }
+                        return message;
+                    };
+
+                    /**
+                     * Decodes a Deployment message from the specified reader or buffer, length delimited.
+                     * @function decodeDelimited
+                     * @memberof google.devtools.cloudprofiler.v2.Deployment
+                     * @static
+                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                     * @returns {google.devtools.cloudprofiler.v2.Deployment} Deployment
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    Deployment.decodeDelimited = function decodeDelimited(reader) {
+                        if (!(reader instanceof $Reader))
+                            reader = new $Reader(reader);
+                        return this.decode(reader, reader.uint32());
+                    };
+
+                    /**
+                     * Verifies a Deployment message.
+                     * @function verify
+                     * @memberof google.devtools.cloudprofiler.v2.Deployment
+                     * @static
+                     * @param {Object.<string,*>} message Plain object to verify
+                     * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                     */
+                    Deployment.verify = function verify(message) {
+                        if (typeof message !== "object" || message === null)
+                            return "object expected";
+                        if (message.projectId != null && message.hasOwnProperty("projectId"))
+                            if (!$util.isString(message.projectId))
+                                return "projectId: string expected";
+                        if (message.target != null && message.hasOwnProperty("target"))
+                            if (!$util.isString(message.target))
+                                return "target: string expected";
+                        if (message.labels != null && message.hasOwnProperty("labels")) {
+                            if (!$util.isObject(message.labels))
+                                return "labels: object expected";
+                            var key = Object.keys(message.labels);
+                            for (var i = 0; i < key.length; ++i)
+                                if (!$util.isString(message.labels[key[i]]))
+                                    return "labels: string{k:string} expected";
+                        }
+                        return null;
+                    };
+
+                    /**
+                     * Creates a Deployment message from a plain object. Also converts values to their respective internal types.
+                     * @function fromObject
+                     * @memberof google.devtools.cloudprofiler.v2.Deployment
+                     * @static
+                     * @param {Object.<string,*>} object Plain object
+                     * @returns {google.devtools.cloudprofiler.v2.Deployment} Deployment
+                     */
+                    Deployment.fromObject = function fromObject(object) {
+                        if (object instanceof $root.google.devtools.cloudprofiler.v2.Deployment)
+                            return object;
+                        var message = new $root.google.devtools.cloudprofiler.v2.Deployment();
+                        if (object.projectId != null)
+                            message.projectId = String(object.projectId);
+                        if (object.target != null)
+                            message.target = String(object.target);
+                        if (object.labels) {
+                            if (typeof object.labels !== "object")
+                                throw TypeError(".google.devtools.cloudprofiler.v2.Deployment.labels: object expected");
+                            message.labels = {};
+                            for (var keys = Object.keys(object.labels), i = 0; i < keys.length; ++i)
+                                message.labels[keys[i]] = String(object.labels[keys[i]]);
+                        }
+                        return message;
+                    };
+
+                    /**
+                     * Creates a plain object from a Deployment message. Also converts values to other types if specified.
+                     * @function toObject
+                     * @memberof google.devtools.cloudprofiler.v2.Deployment
+                     * @static
+                     * @param {google.devtools.cloudprofiler.v2.Deployment} message Deployment
+                     * @param {$protobuf.IConversionOptions} [options] Conversion options
+                     * @returns {Object.<string,*>} Plain object
+                     */
+                    Deployment.toObject = function toObject(message, options) {
+                        if (!options)
+                            options = {};
+                        var object = {};
+                        if (options.objects || options.defaults)
+                            object.labels = {};
+                        if (options.defaults) {
+                            object.projectId = "";
+                            object.target = "";
+                        }
+                        if (message.projectId != null && message.hasOwnProperty("projectId"))
+                            object.projectId = message.projectId;
+                        if (message.target != null && message.hasOwnProperty("target"))
+                            object.target = message.target;
+                        var keys2;
+                        if (message.labels && (keys2 = Object.keys(message.labels)).length) {
+                            object.labels = {};
+                            for (var j = 0; j < keys2.length; ++j)
+                                object.labels[keys2[j]] = message.labels[keys2[j]];
+                        }
+                        return object;
+                    };
+
+                    /**
+                     * Converts this Deployment to JSON.
+                     * @function toJSON
+                     * @memberof google.devtools.cloudprofiler.v2.Deployment
+                     * @instance
+                     * @returns {Object.<string,*>} JSON object
+                     */
+                    Deployment.prototype.toJSON = function toJSON() {
+                        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                    };
+
+                    return Deployment;
+                })();
+
+                /**
+                 * ProfileType enum.
+                 * @enum {string}
+                 * @property {number} PROFILE_TYPE_UNSPECIFIED=0 PROFILE_TYPE_UNSPECIFIED value
+                 * @property {number} CPU=1 CPU value
+                 * @property {number} WALL=2 WALL value
+                 * @property {number} HEAP=3 HEAP value
+                 * @property {number} THREADS=4 THREADS value
+                 * @property {number} CONTENTION=5 CONTENTION value
+                 */
+                v2.ProfileType = (function() {
+                    var valuesById = {}, values = Object.create(valuesById);
+                    values[valuesById[0] = "PROFILE_TYPE_UNSPECIFIED"] = 0;
+                    values[valuesById[1] = "CPU"] = 1;
+                    values[valuesById[2] = "WALL"] = 2;
+                    values[valuesById[3] = "HEAP"] = 3;
+                    values[valuesById[4] = "THREADS"] = 4;
+                    values[valuesById[5] = "CONTENTION"] = 5;
+                    return values;
+                })();
+
+                return v2;
+            })();
+
+            return cloudprofiler;
+        })();
+
+        return devtools;
+    })();
+
+    google.api = (function() {
+
+        /**
+         * Namespace api.
+         * @memberof google
+         * @namespace
+         */
+        var api = {};
+
+        api.Http = (function() {
+
+            /**
+             * Properties of a Http.
+             * @memberof google.api
+             * @interface IHttp
+             * @property {Array.<google.api.IHttpRule>} [rules] Http rules
+             */
+
+            /**
+             * Constructs a new Http.
+             * @memberof google.api
+             * @classdesc Represents a Http.
+             * @constructor
+             * @param {google.api.IHttp=} [properties] Properties to set
+             */
+            function Http(properties) {
+                this.rules = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * Http rules.
+             * @member {Array.<google.api.IHttpRule>}rules
+             * @memberof google.api.Http
+             * @instance
+             */
+            Http.prototype.rules = $util.emptyArray;
+
+            /**
+             * Creates a new Http instance using the specified properties.
+             * @function create
+             * @memberof google.api.Http
+             * @static
+             * @param {google.api.IHttp=} [properties] Properties to set
+             * @returns {google.api.Http} Http instance
+             */
+            Http.create = function create(properties) {
+                return new Http(properties);
+            };
+
+            /**
+             * Encodes the specified Http message. Does not implicitly {@link google.api.Http.verify|verify} messages.
+             * @function encode
+             * @memberof google.api.Http
+             * @static
+             * @param {google.api.IHttp} message Http message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            Http.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.rules != null && message.rules.length)
+                    for (var i = 0; i < message.rules.length; ++i)
+                        $root.google.api.HttpRule.encode(message.rules[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified Http message, length delimited. Does not implicitly {@link google.api.Http.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.api.Http
+             * @static
+             * @param {google.api.IHttp} message Http message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            Http.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a Http message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.api.Http
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.api.Http} Http
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            Http.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.api.Http();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        if (!(message.rules && message.rules.length))
+                            message.rules = [];
+                        message.rules.push($root.google.api.HttpRule.decode(reader, reader.uint32()));
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a Http message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.api.Http
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.api.Http} Http
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            Http.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a Http message.
+             * @function verify
+             * @memberof google.api.Http
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            Http.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.rules != null && message.hasOwnProperty("rules")) {
+                    if (!Array.isArray(message.rules))
+                        return "rules: array expected";
+                    for (var i = 0; i < message.rules.length; ++i) {
+                        var error = $root.google.api.HttpRule.verify(message.rules[i]);
+                        if (error)
+                            return "rules." + error;
+                    }
+                }
+                return null;
+            };
+
+            /**
+             * Creates a Http message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.api.Http
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.api.Http} Http
+             */
+            Http.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.api.Http)
+                    return object;
+                var message = new $root.google.api.Http();
+                if (object.rules) {
+                    if (!Array.isArray(object.rules))
+                        throw TypeError(".google.api.Http.rules: array expected");
+                    message.rules = [];
+                    for (var i = 0; i < object.rules.length; ++i) {
+                        if (typeof object.rules[i] !== "object")
+                            throw TypeError(".google.api.Http.rules: object expected");
+                        message.rules[i] = $root.google.api.HttpRule.fromObject(object.rules[i]);
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a Http message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.api.Http
+             * @static
+             * @param {google.api.Http} message Http
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            Http.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.rules = [];
+                if (message.rules && message.rules.length) {
+                    object.rules = [];
+                    for (var j = 0; j < message.rules.length; ++j)
+                        object.rules[j] = $root.google.api.HttpRule.toObject(message.rules[j], options);
+                }
+                return object;
+            };
+
+            /**
+             * Converts this Http to JSON.
+             * @function toJSON
+             * @memberof google.api.Http
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            Http.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return Http;
+        })();
+
+        api.HttpRule = (function() {
+
+            /**
+             * Properties of a HttpRule.
+             * @memberof google.api
+             * @interface IHttpRule
+             * @property {string} [get] HttpRule get
+             * @property {string} [put] HttpRule put
+             * @property {string} [post] HttpRule post
+             * @property {string} ["delete"] HttpRule delete
+             * @property {string} [patch] HttpRule patch
+             * @property {google.api.ICustomHttpPattern} [custom] HttpRule custom
+             * @property {string} [selector] HttpRule selector
+             * @property {string} [body] HttpRule body
+             * @property {Array.<google.api.IHttpRule>} [additionalBindings] HttpRule additionalBindings
+             */
+
+            /**
+             * Constructs a new HttpRule.
+             * @memberof google.api
+             * @classdesc Represents a HttpRule.
+             * @constructor
+             * @param {google.api.IHttpRule=} [properties] Properties to set
+             */
+            function HttpRule(properties) {
+                this.additionalBindings = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * HttpRule get.
+             * @member {string}get
+             * @memberof google.api.HttpRule
+             * @instance
+             */
+            HttpRule.prototype.get = "";
+
+            /**
+             * HttpRule put.
+             * @member {string}put
+             * @memberof google.api.HttpRule
+             * @instance
+             */
+            HttpRule.prototype.put = "";
+
+            /**
+             * HttpRule post.
+             * @member {string}post
+             * @memberof google.api.HttpRule
+             * @instance
+             */
+            HttpRule.prototype.post = "";
+
+            /**
+             * HttpRule delete.
+             * @member {string}delete_
+             * @memberof google.api.HttpRule
+             * @instance
+             */
+            HttpRule.prototype["delete"] = "";
+
+            /**
+             * HttpRule patch.
+             * @member {string}patch
+             * @memberof google.api.HttpRule
+             * @instance
+             */
+            HttpRule.prototype.patch = "";
+
+            /**
+             * HttpRule custom.
+             * @member {(google.api.ICustomHttpPattern|null|undefined)}custom
+             * @memberof google.api.HttpRule
+             * @instance
+             */
+            HttpRule.prototype.custom = null;
+
+            /**
+             * HttpRule selector.
+             * @member {string}selector
+             * @memberof google.api.HttpRule
+             * @instance
+             */
+            HttpRule.prototype.selector = "";
+
+            /**
+             * HttpRule body.
+             * @member {string}body
+             * @memberof google.api.HttpRule
+             * @instance
+             */
+            HttpRule.prototype.body = "";
+
+            /**
+             * HttpRule additionalBindings.
+             * @member {Array.<google.api.IHttpRule>}additionalBindings
+             * @memberof google.api.HttpRule
+             * @instance
+             */
+            HttpRule.prototype.additionalBindings = $util.emptyArray;
+
+            // OneOf field names bound to virtual getters and setters
+            var $oneOfFields;
+
+            /**
+             * HttpRule pattern.
+             * @member {string|undefined} pattern
+             * @memberof google.api.HttpRule
+             * @instance
+             */
+            Object.defineProperty(HttpRule.prototype, "pattern", {
+                get: $util.oneOfGetter($oneOfFields = ["get", "put", "post", "delete", "patch", "custom"]),
+                set: $util.oneOfSetter($oneOfFields)
+            });
+
+            /**
+             * Creates a new HttpRule instance using the specified properties.
+             * @function create
+             * @memberof google.api.HttpRule
+             * @static
+             * @param {google.api.IHttpRule=} [properties] Properties to set
+             * @returns {google.api.HttpRule} HttpRule instance
+             */
+            HttpRule.create = function create(properties) {
+                return new HttpRule(properties);
+            };
+
+            /**
+             * Encodes the specified HttpRule message. Does not implicitly {@link google.api.HttpRule.verify|verify} messages.
+             * @function encode
+             * @memberof google.api.HttpRule
+             * @static
+             * @param {google.api.IHttpRule} message HttpRule message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            HttpRule.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.selector != null && message.hasOwnProperty("selector"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.selector);
+                if (message.get != null && message.hasOwnProperty("get"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.get);
+                if (message.put != null && message.hasOwnProperty("put"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.put);
+                if (message.post != null && message.hasOwnProperty("post"))
+                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.post);
+                if (message["delete"] != null && message.hasOwnProperty("delete"))
+                    writer.uint32(/* id 5, wireType 2 =*/42).string(message["delete"]);
+                if (message.patch != null && message.hasOwnProperty("patch"))
+                    writer.uint32(/* id 6, wireType 2 =*/50).string(message.patch);
+                if (message.body != null && message.hasOwnProperty("body"))
+                    writer.uint32(/* id 7, wireType 2 =*/58).string(message.body);
+                if (message.custom != null && message.hasOwnProperty("custom"))
+                    $root.google.api.CustomHttpPattern.encode(message.custom, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
+                if (message.additionalBindings != null && message.additionalBindings.length)
+                    for (var i = 0; i < message.additionalBindings.length; ++i)
+                        $root.google.api.HttpRule.encode(message.additionalBindings[i], writer.uint32(/* id 11, wireType 2 =*/90).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified HttpRule message, length delimited. Does not implicitly {@link google.api.HttpRule.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.api.HttpRule
+             * @static
+             * @param {google.api.IHttpRule} message HttpRule message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            HttpRule.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a HttpRule message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.api.HttpRule
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.api.HttpRule} HttpRule
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            HttpRule.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.api.HttpRule();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 2:
+                        message.get = reader.string();
+                        break;
+                    case 3:
+                        message.put = reader.string();
+                        break;
+                    case 4:
+                        message.post = reader.string();
+                        break;
+                    case 5:
+                        message["delete"] = reader.string();
+                        break;
+                    case 6:
+                        message.patch = reader.string();
+                        break;
+                    case 8:
+                        message.custom = $root.google.api.CustomHttpPattern.decode(reader, reader.uint32());
+                        break;
+                    case 1:
+                        message.selector = reader.string();
+                        break;
+                    case 7:
+                        message.body = reader.string();
+                        break;
+                    case 11:
+                        if (!(message.additionalBindings && message.additionalBindings.length))
+                            message.additionalBindings = [];
+                        message.additionalBindings.push($root.google.api.HttpRule.decode(reader, reader.uint32()));
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a HttpRule message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.api.HttpRule
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.api.HttpRule} HttpRule
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            HttpRule.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a HttpRule message.
+             * @function verify
+             * @memberof google.api.HttpRule
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            HttpRule.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                var properties = {};
+                if (message.get != null && message.hasOwnProperty("get")) {
+                    properties.pattern = 1;
+                    if (!$util.isString(message.get))
+                        return "get: string expected";
+                }
+                if (message.put != null && message.hasOwnProperty("put")) {
+                    if (properties.pattern === 1)
+                        return "pattern: multiple values";
+                    properties.pattern = 1;
+                    if (!$util.isString(message.put))
+                        return "put: string expected";
+                }
+                if (message.post != null && message.hasOwnProperty("post")) {
+                    if (properties.pattern === 1)
+                        return "pattern: multiple values";
+                    properties.pattern = 1;
+                    if (!$util.isString(message.post))
+                        return "post: string expected";
+                }
+                if (message["delete"] != null && message.hasOwnProperty("delete")) {
+                    if (properties.pattern === 1)
+                        return "pattern: multiple values";
+                    properties.pattern = 1;
+                    if (!$util.isString(message["delete"]))
+                        return "delete: string expected";
+                }
+                if (message.patch != null && message.hasOwnProperty("patch")) {
+                    if (properties.pattern === 1)
+                        return "pattern: multiple values";
+                    properties.pattern = 1;
+                    if (!$util.isString(message.patch))
+                        return "patch: string expected";
+                }
+                if (message.custom != null && message.hasOwnProperty("custom")) {
+                    if (properties.pattern === 1)
+                        return "pattern: multiple values";
+                    properties.pattern = 1;
+                    var error = $root.google.api.CustomHttpPattern.verify(message.custom);
+                    if (error)
+                        return "custom." + error;
+                }
+                if (message.selector != null && message.hasOwnProperty("selector"))
+                    if (!$util.isString(message.selector))
+                        return "selector: string expected";
+                if (message.body != null && message.hasOwnProperty("body"))
+                    if (!$util.isString(message.body))
+                        return "body: string expected";
+                if (message.additionalBindings != null && message.hasOwnProperty("additionalBindings")) {
+                    if (!Array.isArray(message.additionalBindings))
+                        return "additionalBindings: array expected";
+                    for (var i = 0; i < message.additionalBindings.length; ++i) {
+                        error = $root.google.api.HttpRule.verify(message.additionalBindings[i]);
+                        if (error)
+                            return "additionalBindings." + error;
+                    }
+                }
+                return null;
+            };
+
+            /**
+             * Creates a HttpRule message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.api.HttpRule
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.api.HttpRule} HttpRule
+             */
+            HttpRule.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.api.HttpRule)
+                    return object;
+                var message = new $root.google.api.HttpRule();
+                if (object.get != null)
+                    message.get = String(object.get);
+                if (object.put != null)
+                    message.put = String(object.put);
+                if (object.post != null)
+                    message.post = String(object.post);
+                if (object["delete"] != null)
+                    message["delete"] = String(object["delete"]);
+                if (object.patch != null)
+                    message.patch = String(object.patch);
+                if (object.custom != null) {
+                    if (typeof object.custom !== "object")
+                        throw TypeError(".google.api.HttpRule.custom: object expected");
+                    message.custom = $root.google.api.CustomHttpPattern.fromObject(object.custom);
+                }
+                if (object.selector != null)
+                    message.selector = String(object.selector);
+                if (object.body != null)
+                    message.body = String(object.body);
+                if (object.additionalBindings) {
+                    if (!Array.isArray(object.additionalBindings))
+                        throw TypeError(".google.api.HttpRule.additionalBindings: array expected");
+                    message.additionalBindings = [];
+                    for (var i = 0; i < object.additionalBindings.length; ++i) {
+                        if (typeof object.additionalBindings[i] !== "object")
+                            throw TypeError(".google.api.HttpRule.additionalBindings: object expected");
+                        message.additionalBindings[i] = $root.google.api.HttpRule.fromObject(object.additionalBindings[i]);
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a HttpRule message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.api.HttpRule
+             * @static
+             * @param {google.api.HttpRule} message HttpRule
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            HttpRule.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.additionalBindings = [];
+                if (options.defaults) {
+                    object.selector = "";
+                    object.body = "";
+                }
+                if (message.selector != null && message.hasOwnProperty("selector"))
+                    object.selector = message.selector;
+                if (message.get != null && message.hasOwnProperty("get")) {
+                    object.get = message.get;
+                    if (options.oneofs)
+                        object.pattern = "get";
+                }
+                if (message.put != null && message.hasOwnProperty("put")) {
+                    object.put = message.put;
+                    if (options.oneofs)
+                        object.pattern = "put";
+                }
+                if (message.post != null && message.hasOwnProperty("post")) {
+                    object.post = message.post;
+                    if (options.oneofs)
+                        object.pattern = "post";
+                }
+                if (message["delete"] != null && message.hasOwnProperty("delete")) {
+                    object["delete"] = message["delete"];
+                    if (options.oneofs)
+                        object.pattern = "delete";
+                }
+                if (message.patch != null && message.hasOwnProperty("patch")) {
+                    object.patch = message.patch;
+                    if (options.oneofs)
+                        object.pattern = "patch";
+                }
+                if (message.body != null && message.hasOwnProperty("body"))
+                    object.body = message.body;
+                if (message.custom != null && message.hasOwnProperty("custom")) {
+                    object.custom = $root.google.api.CustomHttpPattern.toObject(message.custom, options);
+                    if (options.oneofs)
+                        object.pattern = "custom";
+                }
+                if (message.additionalBindings && message.additionalBindings.length) {
+                    object.additionalBindings = [];
+                    for (var j = 0; j < message.additionalBindings.length; ++j)
+                        object.additionalBindings[j] = $root.google.api.HttpRule.toObject(message.additionalBindings[j], options);
+                }
+                return object;
+            };
+
+            /**
+             * Converts this HttpRule to JSON.
+             * @function toJSON
+             * @memberof google.api.HttpRule
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            HttpRule.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return HttpRule;
+        })();
+
+        api.CustomHttpPattern = (function() {
+
+            /**
+             * Properties of a CustomHttpPattern.
+             * @memberof google.api
+             * @interface ICustomHttpPattern
+             * @property {string} [kind] CustomHttpPattern kind
+             * @property {string} [path] CustomHttpPattern path
+             */
+
+            /**
+             * Constructs a new CustomHttpPattern.
+             * @memberof google.api
+             * @classdesc Represents a CustomHttpPattern.
+             * @constructor
+             * @param {google.api.ICustomHttpPattern=} [properties] Properties to set
+             */
+            function CustomHttpPattern(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * CustomHttpPattern kind.
+             * @member {string}kind
+             * @memberof google.api.CustomHttpPattern
+             * @instance
+             */
+            CustomHttpPattern.prototype.kind = "";
+
+            /**
+             * CustomHttpPattern path.
+             * @member {string}path
+             * @memberof google.api.CustomHttpPattern
+             * @instance
+             */
+            CustomHttpPattern.prototype.path = "";
+
+            /**
+             * Creates a new CustomHttpPattern instance using the specified properties.
+             * @function create
+             * @memberof google.api.CustomHttpPattern
+             * @static
+             * @param {google.api.ICustomHttpPattern=} [properties] Properties to set
+             * @returns {google.api.CustomHttpPattern} CustomHttpPattern instance
+             */
+            CustomHttpPattern.create = function create(properties) {
+                return new CustomHttpPattern(properties);
+            };
+
+            /**
+             * Encodes the specified CustomHttpPattern message. Does not implicitly {@link google.api.CustomHttpPattern.verify|verify} messages.
+             * @function encode
+             * @memberof google.api.CustomHttpPattern
+             * @static
+             * @param {google.api.ICustomHttpPattern} message CustomHttpPattern message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            CustomHttpPattern.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.kind != null && message.hasOwnProperty("kind"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.kind);
+                if (message.path != null && message.hasOwnProperty("path"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.path);
+                return writer;
+            };
+
+            /**
+             * Encodes the specified CustomHttpPattern message, length delimited. Does not implicitly {@link google.api.CustomHttpPattern.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.api.CustomHttpPattern
+             * @static
+             * @param {google.api.ICustomHttpPattern} message CustomHttpPattern message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            CustomHttpPattern.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a CustomHttpPattern message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.api.CustomHttpPattern
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.api.CustomHttpPattern} CustomHttpPattern
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            CustomHttpPattern.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.api.CustomHttpPattern();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.kind = reader.string();
+                        break;
+                    case 2:
+                        message.path = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a CustomHttpPattern message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.api.CustomHttpPattern
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.api.CustomHttpPattern} CustomHttpPattern
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            CustomHttpPattern.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a CustomHttpPattern message.
+             * @function verify
+             * @memberof google.api.CustomHttpPattern
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            CustomHttpPattern.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.kind != null && message.hasOwnProperty("kind"))
+                    if (!$util.isString(message.kind))
+                        return "kind: string expected";
+                if (message.path != null && message.hasOwnProperty("path"))
+                    if (!$util.isString(message.path))
+                        return "path: string expected";
+                return null;
+            };
+
+            /**
+             * Creates a CustomHttpPattern message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.api.CustomHttpPattern
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.api.CustomHttpPattern} CustomHttpPattern
+             */
+            CustomHttpPattern.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.api.CustomHttpPattern)
+                    return object;
+                var message = new $root.google.api.CustomHttpPattern();
+                if (object.kind != null)
+                    message.kind = String(object.kind);
+                if (object.path != null)
+                    message.path = String(object.path);
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a CustomHttpPattern message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.api.CustomHttpPattern
+             * @static
+             * @param {google.api.CustomHttpPattern} message CustomHttpPattern
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            CustomHttpPattern.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.kind = "";
+                    object.path = "";
+                }
+                if (message.kind != null && message.hasOwnProperty("kind"))
+                    object.kind = message.kind;
+                if (message.path != null && message.hasOwnProperty("path"))
+                    object.path = message.path;
+                return object;
+            };
+
+            /**
+             * Converts this CustomHttpPattern to JSON.
+             * @function toJSON
+             * @memberof google.api.CustomHttpPattern
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            CustomHttpPattern.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return CustomHttpPattern;
+        })();
+
+        return api;
+    })();
+
+    google.protobuf = (function() {
+
+        /**
+         * Namespace protobuf.
+         * @memberof google
+         * @namespace
+         */
+        var protobuf = {};
+
+        protobuf.FileDescriptorSet = (function() {
+
+            /**
+             * Properties of a FileDescriptorSet.
+             * @memberof google.protobuf
+             * @interface IFileDescriptorSet
+             * @property {Array.<google.protobuf.IFileDescriptorProto>} [file] FileDescriptorSet file
+             */
+
+            /**
+             * Constructs a new FileDescriptorSet.
+             * @memberof google.protobuf
+             * @classdesc Represents a FileDescriptorSet.
+             * @constructor
+             * @param {google.protobuf.IFileDescriptorSet=} [properties] Properties to set
+             */
+            function FileDescriptorSet(properties) {
+                this.file = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * FileDescriptorSet file.
+             * @member {Array.<google.protobuf.IFileDescriptorProto>}file
+             * @memberof google.protobuf.FileDescriptorSet
+             * @instance
+             */
+            FileDescriptorSet.prototype.file = $util.emptyArray;
+
+            /**
+             * Creates a new FileDescriptorSet instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.FileDescriptorSet
+             * @static
+             * @param {google.protobuf.IFileDescriptorSet=} [properties] Properties to set
+             * @returns {google.protobuf.FileDescriptorSet} FileDescriptorSet instance
+             */
+            FileDescriptorSet.create = function create(properties) {
+                return new FileDescriptorSet(properties);
+            };
+
+            /**
+             * Encodes the specified FileDescriptorSet message. Does not implicitly {@link google.protobuf.FileDescriptorSet.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.FileDescriptorSet
+             * @static
+             * @param {google.protobuf.IFileDescriptorSet} message FileDescriptorSet message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            FileDescriptorSet.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.file != null && message.file.length)
+                    for (var i = 0; i < message.file.length; ++i)
+                        $root.google.protobuf.FileDescriptorProto.encode(message.file[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified FileDescriptorSet message, length delimited. Does not implicitly {@link google.protobuf.FileDescriptorSet.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.FileDescriptorSet
+             * @static
+             * @param {google.protobuf.IFileDescriptorSet} message FileDescriptorSet message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            FileDescriptorSet.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a FileDescriptorSet message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.FileDescriptorSet
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.FileDescriptorSet} FileDescriptorSet
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            FileDescriptorSet.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.FileDescriptorSet();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        if (!(message.file && message.file.length))
+                            message.file = [];
+                        message.file.push($root.google.protobuf.FileDescriptorProto.decode(reader, reader.uint32()));
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a FileDescriptorSet message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.FileDescriptorSet
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.FileDescriptorSet} FileDescriptorSet
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            FileDescriptorSet.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a FileDescriptorSet message.
+             * @function verify
+             * @memberof google.protobuf.FileDescriptorSet
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            FileDescriptorSet.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.file != null && message.hasOwnProperty("file")) {
+                    if (!Array.isArray(message.file))
+                        return "file: array expected";
+                    for (var i = 0; i < message.file.length; ++i) {
+                        var error = $root.google.protobuf.FileDescriptorProto.verify(message.file[i]);
+                        if (error)
+                            return "file." + error;
+                    }
+                }
+                return null;
+            };
+
+            /**
+             * Creates a FileDescriptorSet message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.FileDescriptorSet
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.FileDescriptorSet} FileDescriptorSet
+             */
+            FileDescriptorSet.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.FileDescriptorSet)
+                    return object;
+                var message = new $root.google.protobuf.FileDescriptorSet();
+                if (object.file) {
+                    if (!Array.isArray(object.file))
+                        throw TypeError(".google.protobuf.FileDescriptorSet.file: array expected");
+                    message.file = [];
+                    for (var i = 0; i < object.file.length; ++i) {
+                        if (typeof object.file[i] !== "object")
+                            throw TypeError(".google.protobuf.FileDescriptorSet.file: object expected");
+                        message.file[i] = $root.google.protobuf.FileDescriptorProto.fromObject(object.file[i]);
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a FileDescriptorSet message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.FileDescriptorSet
+             * @static
+             * @param {google.protobuf.FileDescriptorSet} message FileDescriptorSet
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            FileDescriptorSet.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.file = [];
+                if (message.file && message.file.length) {
+                    object.file = [];
+                    for (var j = 0; j < message.file.length; ++j)
+                        object.file[j] = $root.google.protobuf.FileDescriptorProto.toObject(message.file[j], options);
+                }
+                return object;
+            };
+
+            /**
+             * Converts this FileDescriptorSet to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.FileDescriptorSet
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            FileDescriptorSet.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return FileDescriptorSet;
+        })();
+
+        protobuf.FileDescriptorProto = (function() {
+
+            /**
+             * Properties of a FileDescriptorProto.
+             * @memberof google.protobuf
+             * @interface IFileDescriptorProto
+             * @property {string} [name] FileDescriptorProto name
+             * @property {string} ["package"] FileDescriptorProto package
+             * @property {Array.<string>} [dependency] FileDescriptorProto dependency
+             * @property {Array.<number>} [publicDependency] FileDescriptorProto publicDependency
+             * @property {Array.<number>} [weakDependency] FileDescriptorProto weakDependency
+             * @property {Array.<google.protobuf.IDescriptorProto>} [messageType] FileDescriptorProto messageType
+             * @property {Array.<google.protobuf.IEnumDescriptorProto>} [enumType] FileDescriptorProto enumType
+             * @property {Array.<google.protobuf.IServiceDescriptorProto>} [service] FileDescriptorProto service
+             * @property {Array.<google.protobuf.IFieldDescriptorProto>} [extension] FileDescriptorProto extension
+             * @property {google.protobuf.IFileOptions} [options] FileDescriptorProto options
+             * @property {google.protobuf.ISourceCodeInfo} [sourceCodeInfo] FileDescriptorProto sourceCodeInfo
+             * @property {string} [syntax] FileDescriptorProto syntax
+             */
+
+            /**
+             * Constructs a new FileDescriptorProto.
+             * @memberof google.protobuf
+             * @classdesc Represents a FileDescriptorProto.
+             * @constructor
+             * @param {google.protobuf.IFileDescriptorProto=} [properties] Properties to set
+             */
+            function FileDescriptorProto(properties) {
+                this.dependency = [];
+                this.publicDependency = [];
+                this.weakDependency = [];
+                this.messageType = [];
+                this.enumType = [];
+                this.service = [];
+                this.extension = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * FileDescriptorProto name.
+             * @member {string}name
+             * @memberof google.protobuf.FileDescriptorProto
+             * @instance
+             */
+            FileDescriptorProto.prototype.name = "";
+
+            /**
+             * FileDescriptorProto package.
+             * @member {string}package_
+             * @memberof google.protobuf.FileDescriptorProto
+             * @instance
+             */
+            FileDescriptorProto.prototype["package"] = "";
+
+            /**
+             * FileDescriptorProto dependency.
+             * @member {Array.<string>}dependency
+             * @memberof google.protobuf.FileDescriptorProto
+             * @instance
+             */
+            FileDescriptorProto.prototype.dependency = $util.emptyArray;
+
+            /**
+             * FileDescriptorProto publicDependency.
+             * @member {Array.<number>}publicDependency
+             * @memberof google.protobuf.FileDescriptorProto
+             * @instance
+             */
+            FileDescriptorProto.prototype.publicDependency = $util.emptyArray;
+
+            /**
+             * FileDescriptorProto weakDependency.
+             * @member {Array.<number>}weakDependency
+             * @memberof google.protobuf.FileDescriptorProto
+             * @instance
+             */
+            FileDescriptorProto.prototype.weakDependency = $util.emptyArray;
+
+            /**
+             * FileDescriptorProto messageType.
+             * @member {Array.<google.protobuf.IDescriptorProto>}messageType
+             * @memberof google.protobuf.FileDescriptorProto
+             * @instance
+             */
+            FileDescriptorProto.prototype.messageType = $util.emptyArray;
+
+            /**
+             * FileDescriptorProto enumType.
+             * @member {Array.<google.protobuf.IEnumDescriptorProto>}enumType
+             * @memberof google.protobuf.FileDescriptorProto
+             * @instance
+             */
+            FileDescriptorProto.prototype.enumType = $util.emptyArray;
+
+            /**
+             * FileDescriptorProto service.
+             * @member {Array.<google.protobuf.IServiceDescriptorProto>}service
+             * @memberof google.protobuf.FileDescriptorProto
+             * @instance
+             */
+            FileDescriptorProto.prototype.service = $util.emptyArray;
+
+            /**
+             * FileDescriptorProto extension.
+             * @member {Array.<google.protobuf.IFieldDescriptorProto>}extension
+             * @memberof google.protobuf.FileDescriptorProto
+             * @instance
+             */
+            FileDescriptorProto.prototype.extension = $util.emptyArray;
+
+            /**
+             * FileDescriptorProto options.
+             * @member {(google.protobuf.IFileOptions|null|undefined)}options
+             * @memberof google.protobuf.FileDescriptorProto
+             * @instance
+             */
+            FileDescriptorProto.prototype.options = null;
+
+            /**
+             * FileDescriptorProto sourceCodeInfo.
+             * @member {(google.protobuf.ISourceCodeInfo|null|undefined)}sourceCodeInfo
+             * @memberof google.protobuf.FileDescriptorProto
+             * @instance
+             */
+            FileDescriptorProto.prototype.sourceCodeInfo = null;
+
+            /**
+             * FileDescriptorProto syntax.
+             * @member {string}syntax
+             * @memberof google.protobuf.FileDescriptorProto
+             * @instance
+             */
+            FileDescriptorProto.prototype.syntax = "";
+
+            /**
+             * Creates a new FileDescriptorProto instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.FileDescriptorProto
+             * @static
+             * @param {google.protobuf.IFileDescriptorProto=} [properties] Properties to set
+             * @returns {google.protobuf.FileDescriptorProto} FileDescriptorProto instance
+             */
+            FileDescriptorProto.create = function create(properties) {
+                return new FileDescriptorProto(properties);
+            };
+
+            /**
+             * Encodes the specified FileDescriptorProto message. Does not implicitly {@link google.protobuf.FileDescriptorProto.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.FileDescriptorProto
+             * @static
+             * @param {google.protobuf.IFileDescriptorProto} message FileDescriptorProto message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            FileDescriptorProto.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.name != null && message.hasOwnProperty("name"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
+                if (message["package"] != null && message.hasOwnProperty("package"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message["package"]);
+                if (message.dependency != null && message.dependency.length)
+                    for (var i = 0; i < message.dependency.length; ++i)
+                        writer.uint32(/* id 3, wireType 2 =*/26).string(message.dependency[i]);
+                if (message.messageType != null && message.messageType.length)
+                    for (var i = 0; i < message.messageType.length; ++i)
+                        $root.google.protobuf.DescriptorProto.encode(message.messageType[i], writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                if (message.enumType != null && message.enumType.length)
+                    for (var i = 0; i < message.enumType.length; ++i)
+                        $root.google.protobuf.EnumDescriptorProto.encode(message.enumType[i], writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+                if (message.service != null && message.service.length)
+                    for (var i = 0; i < message.service.length; ++i)
+                        $root.google.protobuf.ServiceDescriptorProto.encode(message.service[i], writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
+                if (message.extension != null && message.extension.length)
+                    for (var i = 0; i < message.extension.length; ++i)
+                        $root.google.protobuf.FieldDescriptorProto.encode(message.extension[i], writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+                if (message.options != null && message.hasOwnProperty("options"))
+                    $root.google.protobuf.FileOptions.encode(message.options, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
+                if (message.sourceCodeInfo != null && message.hasOwnProperty("sourceCodeInfo"))
+                    $root.google.protobuf.SourceCodeInfo.encode(message.sourceCodeInfo, writer.uint32(/* id 9, wireType 2 =*/74).fork()).ldelim();
+                if (message.publicDependency != null && message.publicDependency.length)
+                    for (var i = 0; i < message.publicDependency.length; ++i)
+                        writer.uint32(/* id 10, wireType 0 =*/80).int32(message.publicDependency[i]);
+                if (message.weakDependency != null && message.weakDependency.length)
+                    for (var i = 0; i < message.weakDependency.length; ++i)
+                        writer.uint32(/* id 11, wireType 0 =*/88).int32(message.weakDependency[i]);
+                if (message.syntax != null && message.hasOwnProperty("syntax"))
+                    writer.uint32(/* id 12, wireType 2 =*/98).string(message.syntax);
+                return writer;
+            };
+
+            /**
+             * Encodes the specified FileDescriptorProto message, length delimited. Does not implicitly {@link google.protobuf.FileDescriptorProto.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.FileDescriptorProto
+             * @static
+             * @param {google.protobuf.IFileDescriptorProto} message FileDescriptorProto message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            FileDescriptorProto.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a FileDescriptorProto message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.FileDescriptorProto
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.FileDescriptorProto} FileDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            FileDescriptorProto.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.FileDescriptorProto();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.name = reader.string();
+                        break;
+                    case 2:
+                        message["package"] = reader.string();
+                        break;
+                    case 3:
+                        if (!(message.dependency && message.dependency.length))
+                            message.dependency = [];
+                        message.dependency.push(reader.string());
+                        break;
+                    case 10:
+                        if (!(message.publicDependency && message.publicDependency.length))
+                            message.publicDependency = [];
+                        if ((tag & 7) === 2) {
+                            var end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.publicDependency.push(reader.int32());
+                        } else
+                            message.publicDependency.push(reader.int32());
+                        break;
+                    case 11:
+                        if (!(message.weakDependency && message.weakDependency.length))
+                            message.weakDependency = [];
+                        if ((tag & 7) === 2) {
+                            var end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.weakDependency.push(reader.int32());
+                        } else
+                            message.weakDependency.push(reader.int32());
+                        break;
+                    case 4:
+                        if (!(message.messageType && message.messageType.length))
+                            message.messageType = [];
+                        message.messageType.push($root.google.protobuf.DescriptorProto.decode(reader, reader.uint32()));
+                        break;
+                    case 5:
+                        if (!(message.enumType && message.enumType.length))
+                            message.enumType = [];
+                        message.enumType.push($root.google.protobuf.EnumDescriptorProto.decode(reader, reader.uint32()));
+                        break;
+                    case 6:
+                        if (!(message.service && message.service.length))
+                            message.service = [];
+                        message.service.push($root.google.protobuf.ServiceDescriptorProto.decode(reader, reader.uint32()));
+                        break;
+                    case 7:
+                        if (!(message.extension && message.extension.length))
+                            message.extension = [];
+                        message.extension.push($root.google.protobuf.FieldDescriptorProto.decode(reader, reader.uint32()));
+                        break;
+                    case 8:
+                        message.options = $root.google.protobuf.FileOptions.decode(reader, reader.uint32());
+                        break;
+                    case 9:
+                        message.sourceCodeInfo = $root.google.protobuf.SourceCodeInfo.decode(reader, reader.uint32());
+                        break;
+                    case 12:
+                        message.syntax = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a FileDescriptorProto message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.FileDescriptorProto
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.FileDescriptorProto} FileDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            FileDescriptorProto.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a FileDescriptorProto message.
+             * @function verify
+             * @memberof google.protobuf.FileDescriptorProto
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            FileDescriptorProto.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.name != null && message.hasOwnProperty("name"))
+                    if (!$util.isString(message.name))
+                        return "name: string expected";
+                if (message["package"] != null && message.hasOwnProperty("package"))
+                    if (!$util.isString(message["package"]))
+                        return "package: string expected";
+                if (message.dependency != null && message.hasOwnProperty("dependency")) {
+                    if (!Array.isArray(message.dependency))
+                        return "dependency: array expected";
+                    for (var i = 0; i < message.dependency.length; ++i)
+                        if (!$util.isString(message.dependency[i]))
+                            return "dependency: string[] expected";
+                }
+                if (message.publicDependency != null && message.hasOwnProperty("publicDependency")) {
+                    if (!Array.isArray(message.publicDependency))
+                        return "publicDependency: array expected";
+                    for (var i = 0; i < message.publicDependency.length; ++i)
+                        if (!$util.isInteger(message.publicDependency[i]))
+                            return "publicDependency: integer[] expected";
+                }
+                if (message.weakDependency != null && message.hasOwnProperty("weakDependency")) {
+                    if (!Array.isArray(message.weakDependency))
+                        return "weakDependency: array expected";
+                    for (var i = 0; i < message.weakDependency.length; ++i)
+                        if (!$util.isInteger(message.weakDependency[i]))
+                            return "weakDependency: integer[] expected";
+                }
+                if (message.messageType != null && message.hasOwnProperty("messageType")) {
+                    if (!Array.isArray(message.messageType))
+                        return "messageType: array expected";
+                    for (var i = 0; i < message.messageType.length; ++i) {
+                        var error = $root.google.protobuf.DescriptorProto.verify(message.messageType[i]);
+                        if (error)
+                            return "messageType." + error;
+                    }
+                }
+                if (message.enumType != null && message.hasOwnProperty("enumType")) {
+                    if (!Array.isArray(message.enumType))
+                        return "enumType: array expected";
+                    for (var i = 0; i < message.enumType.length; ++i) {
+                        error = $root.google.protobuf.EnumDescriptorProto.verify(message.enumType[i]);
+                        if (error)
+                            return "enumType." + error;
+                    }
+                }
+                if (message.service != null && message.hasOwnProperty("service")) {
+                    if (!Array.isArray(message.service))
+                        return "service: array expected";
+                    for (var i = 0; i < message.service.length; ++i) {
+                        error = $root.google.protobuf.ServiceDescriptorProto.verify(message.service[i]);
+                        if (error)
+                            return "service." + error;
+                    }
+                }
+                if (message.extension != null && message.hasOwnProperty("extension")) {
+                    if (!Array.isArray(message.extension))
+                        return "extension: array expected";
+                    for (var i = 0; i < message.extension.length; ++i) {
+                        error = $root.google.protobuf.FieldDescriptorProto.verify(message.extension[i]);
+                        if (error)
+                            return "extension." + error;
+                    }
+                }
+                if (message.options != null && message.hasOwnProperty("options")) {
+                    error = $root.google.protobuf.FileOptions.verify(message.options);
+                    if (error)
+                        return "options." + error;
+                }
+                if (message.sourceCodeInfo != null && message.hasOwnProperty("sourceCodeInfo")) {
+                    error = $root.google.protobuf.SourceCodeInfo.verify(message.sourceCodeInfo);
+                    if (error)
+                        return "sourceCodeInfo." + error;
+                }
+                if (message.syntax != null && message.hasOwnProperty("syntax"))
+                    if (!$util.isString(message.syntax))
+                        return "syntax: string expected";
+                return null;
+            };
+
+            /**
+             * Creates a FileDescriptorProto message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.FileDescriptorProto
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.FileDescriptorProto} FileDescriptorProto
+             */
+            FileDescriptorProto.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.FileDescriptorProto)
+                    return object;
+                var message = new $root.google.protobuf.FileDescriptorProto();
+                if (object.name != null)
+                    message.name = String(object.name);
+                if (object["package"] != null)
+                    message["package"] = String(object["package"]);
+                if (object.dependency) {
+                    if (!Array.isArray(object.dependency))
+                        throw TypeError(".google.protobuf.FileDescriptorProto.dependency: array expected");
+                    message.dependency = [];
+                    for (var i = 0; i < object.dependency.length; ++i)
+                        message.dependency[i] = String(object.dependency[i]);
+                }
+                if (object.publicDependency) {
+                    if (!Array.isArray(object.publicDependency))
+                        throw TypeError(".google.protobuf.FileDescriptorProto.publicDependency: array expected");
+                    message.publicDependency = [];
+                    for (var i = 0; i < object.publicDependency.length; ++i)
+                        message.publicDependency[i] = object.publicDependency[i] | 0;
+                }
+                if (object.weakDependency) {
+                    if (!Array.isArray(object.weakDependency))
+                        throw TypeError(".google.protobuf.FileDescriptorProto.weakDependency: array expected");
+                    message.weakDependency = [];
+                    for (var i = 0; i < object.weakDependency.length; ++i)
+                        message.weakDependency[i] = object.weakDependency[i] | 0;
+                }
+                if (object.messageType) {
+                    if (!Array.isArray(object.messageType))
+                        throw TypeError(".google.protobuf.FileDescriptorProto.messageType: array expected");
+                    message.messageType = [];
+                    for (var i = 0; i < object.messageType.length; ++i) {
+                        if (typeof object.messageType[i] !== "object")
+                            throw TypeError(".google.protobuf.FileDescriptorProto.messageType: object expected");
+                        message.messageType[i] = $root.google.protobuf.DescriptorProto.fromObject(object.messageType[i]);
+                    }
+                }
+                if (object.enumType) {
+                    if (!Array.isArray(object.enumType))
+                        throw TypeError(".google.protobuf.FileDescriptorProto.enumType: array expected");
+                    message.enumType = [];
+                    for (var i = 0; i < object.enumType.length; ++i) {
+                        if (typeof object.enumType[i] !== "object")
+                            throw TypeError(".google.protobuf.FileDescriptorProto.enumType: object expected");
+                        message.enumType[i] = $root.google.protobuf.EnumDescriptorProto.fromObject(object.enumType[i]);
+                    }
+                }
+                if (object.service) {
+                    if (!Array.isArray(object.service))
+                        throw TypeError(".google.protobuf.FileDescriptorProto.service: array expected");
+                    message.service = [];
+                    for (var i = 0; i < object.service.length; ++i) {
+                        if (typeof object.service[i] !== "object")
+                            throw TypeError(".google.protobuf.FileDescriptorProto.service: object expected");
+                        message.service[i] = $root.google.protobuf.ServiceDescriptorProto.fromObject(object.service[i]);
+                    }
+                }
+                if (object.extension) {
+                    if (!Array.isArray(object.extension))
+                        throw TypeError(".google.protobuf.FileDescriptorProto.extension: array expected");
+                    message.extension = [];
+                    for (var i = 0; i < object.extension.length; ++i) {
+                        if (typeof object.extension[i] !== "object")
+                            throw TypeError(".google.protobuf.FileDescriptorProto.extension: object expected");
+                        message.extension[i] = $root.google.protobuf.FieldDescriptorProto.fromObject(object.extension[i]);
+                    }
+                }
+                if (object.options != null) {
+                    if (typeof object.options !== "object")
+                        throw TypeError(".google.protobuf.FileDescriptorProto.options: object expected");
+                    message.options = $root.google.protobuf.FileOptions.fromObject(object.options);
+                }
+                if (object.sourceCodeInfo != null) {
+                    if (typeof object.sourceCodeInfo !== "object")
+                        throw TypeError(".google.protobuf.FileDescriptorProto.sourceCodeInfo: object expected");
+                    message.sourceCodeInfo = $root.google.protobuf.SourceCodeInfo.fromObject(object.sourceCodeInfo);
+                }
+                if (object.syntax != null)
+                    message.syntax = String(object.syntax);
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a FileDescriptorProto message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.FileDescriptorProto
+             * @static
+             * @param {google.protobuf.FileDescriptorProto} message FileDescriptorProto
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            FileDescriptorProto.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults) {
+                    object.dependency = [];
+                    object.messageType = [];
+                    object.enumType = [];
+                    object.service = [];
+                    object.extension = [];
+                    object.publicDependency = [];
+                    object.weakDependency = [];
+                }
+                if (options.defaults) {
+                    object.name = "";
+                    object["package"] = "";
+                    object.options = null;
+                    object.sourceCodeInfo = null;
+                    object.syntax = "";
+                }
+                if (message.name != null && message.hasOwnProperty("name"))
+                    object.name = message.name;
+                if (message["package"] != null && message.hasOwnProperty("package"))
+                    object["package"] = message["package"];
+                if (message.dependency && message.dependency.length) {
+                    object.dependency = [];
+                    for (var j = 0; j < message.dependency.length; ++j)
+                        object.dependency[j] = message.dependency[j];
+                }
+                if (message.messageType && message.messageType.length) {
+                    object.messageType = [];
+                    for (var j = 0; j < message.messageType.length; ++j)
+                        object.messageType[j] = $root.google.protobuf.DescriptorProto.toObject(message.messageType[j], options);
+                }
+                if (message.enumType && message.enumType.length) {
+                    object.enumType = [];
+                    for (var j = 0; j < message.enumType.length; ++j)
+                        object.enumType[j] = $root.google.protobuf.EnumDescriptorProto.toObject(message.enumType[j], options);
+                }
+                if (message.service && message.service.length) {
+                    object.service = [];
+                    for (var j = 0; j < message.service.length; ++j)
+                        object.service[j] = $root.google.protobuf.ServiceDescriptorProto.toObject(message.service[j], options);
+                }
+                if (message.extension && message.extension.length) {
+                    object.extension = [];
+                    for (var j = 0; j < message.extension.length; ++j)
+                        object.extension[j] = $root.google.protobuf.FieldDescriptorProto.toObject(message.extension[j], options);
+                }
+                if (message.options != null && message.hasOwnProperty("options"))
+                    object.options = $root.google.protobuf.FileOptions.toObject(message.options, options);
+                if (message.sourceCodeInfo != null && message.hasOwnProperty("sourceCodeInfo"))
+                    object.sourceCodeInfo = $root.google.protobuf.SourceCodeInfo.toObject(message.sourceCodeInfo, options);
+                if (message.publicDependency && message.publicDependency.length) {
+                    object.publicDependency = [];
+                    for (var j = 0; j < message.publicDependency.length; ++j)
+                        object.publicDependency[j] = message.publicDependency[j];
+                }
+                if (message.weakDependency && message.weakDependency.length) {
+                    object.weakDependency = [];
+                    for (var j = 0; j < message.weakDependency.length; ++j)
+                        object.weakDependency[j] = message.weakDependency[j];
+                }
+                if (message.syntax != null && message.hasOwnProperty("syntax"))
+                    object.syntax = message.syntax;
+                return object;
+            };
+
+            /**
+             * Converts this FileDescriptorProto to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.FileDescriptorProto
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            FileDescriptorProto.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return FileDescriptorProto;
+        })();
+
+        protobuf.DescriptorProto = (function() {
+
+            /**
+             * Properties of a DescriptorProto.
+             * @memberof google.protobuf
+             * @interface IDescriptorProto
+             * @property {string} [name] DescriptorProto name
+             * @property {Array.<google.protobuf.IFieldDescriptorProto>} [field] DescriptorProto field
+             * @property {Array.<google.protobuf.IFieldDescriptorProto>} [extension] DescriptorProto extension
+             * @property {Array.<google.protobuf.IDescriptorProto>} [nestedType] DescriptorProto nestedType
+             * @property {Array.<google.protobuf.IEnumDescriptorProto>} [enumType] DescriptorProto enumType
+             * @property {Array.<google.protobuf.DescriptorProto.IExtensionRange>} [extensionRange] DescriptorProto extensionRange
+             * @property {Array.<google.protobuf.IOneofDescriptorProto>} [oneofDecl] DescriptorProto oneofDecl
+             * @property {google.protobuf.IMessageOptions} [options] DescriptorProto options
+             * @property {Array.<google.protobuf.DescriptorProto.IReservedRange>} [reservedRange] DescriptorProto reservedRange
+             * @property {Array.<string>} [reservedName] DescriptorProto reservedName
+             */
+
+            /**
+             * Constructs a new DescriptorProto.
+             * @memberof google.protobuf
+             * @classdesc Represents a DescriptorProto.
+             * @constructor
+             * @param {google.protobuf.IDescriptorProto=} [properties] Properties to set
+             */
+            function DescriptorProto(properties) {
+                this.field = [];
+                this.extension = [];
+                this.nestedType = [];
+                this.enumType = [];
+                this.extensionRange = [];
+                this.oneofDecl = [];
+                this.reservedRange = [];
+                this.reservedName = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * DescriptorProto name.
+             * @member {string}name
+             * @memberof google.protobuf.DescriptorProto
+             * @instance
+             */
+            DescriptorProto.prototype.name = "";
+
+            /**
+             * DescriptorProto field.
+             * @member {Array.<google.protobuf.IFieldDescriptorProto>}field
+             * @memberof google.protobuf.DescriptorProto
+             * @instance
+             */
+            DescriptorProto.prototype.field = $util.emptyArray;
+
+            /**
+             * DescriptorProto extension.
+             * @member {Array.<google.protobuf.IFieldDescriptorProto>}extension
+             * @memberof google.protobuf.DescriptorProto
+             * @instance
+             */
+            DescriptorProto.prototype.extension = $util.emptyArray;
+
+            /**
+             * DescriptorProto nestedType.
+             * @member {Array.<google.protobuf.IDescriptorProto>}nestedType
+             * @memberof google.protobuf.DescriptorProto
+             * @instance
+             */
+            DescriptorProto.prototype.nestedType = $util.emptyArray;
+
+            /**
+             * DescriptorProto enumType.
+             * @member {Array.<google.protobuf.IEnumDescriptorProto>}enumType
+             * @memberof google.protobuf.DescriptorProto
+             * @instance
+             */
+            DescriptorProto.prototype.enumType = $util.emptyArray;
+
+            /**
+             * DescriptorProto extensionRange.
+             * @member {Array.<google.protobuf.DescriptorProto.IExtensionRange>}extensionRange
+             * @memberof google.protobuf.DescriptorProto
+             * @instance
+             */
+            DescriptorProto.prototype.extensionRange = $util.emptyArray;
+
+            /**
+             * DescriptorProto oneofDecl.
+             * @member {Array.<google.protobuf.IOneofDescriptorProto>}oneofDecl
+             * @memberof google.protobuf.DescriptorProto
+             * @instance
+             */
+            DescriptorProto.prototype.oneofDecl = $util.emptyArray;
+
+            /**
+             * DescriptorProto options.
+             * @member {(google.protobuf.IMessageOptions|null|undefined)}options
+             * @memberof google.protobuf.DescriptorProto
+             * @instance
+             */
+            DescriptorProto.prototype.options = null;
+
+            /**
+             * DescriptorProto reservedRange.
+             * @member {Array.<google.protobuf.DescriptorProto.IReservedRange>}reservedRange
+             * @memberof google.protobuf.DescriptorProto
+             * @instance
+             */
+            DescriptorProto.prototype.reservedRange = $util.emptyArray;
+
+            /**
+             * DescriptorProto reservedName.
+             * @member {Array.<string>}reservedName
+             * @memberof google.protobuf.DescriptorProto
+             * @instance
+             */
+            DescriptorProto.prototype.reservedName = $util.emptyArray;
+
+            /**
+             * Creates a new DescriptorProto instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.DescriptorProto
+             * @static
+             * @param {google.protobuf.IDescriptorProto=} [properties] Properties to set
+             * @returns {google.protobuf.DescriptorProto} DescriptorProto instance
+             */
+            DescriptorProto.create = function create(properties) {
+                return new DescriptorProto(properties);
+            };
+
+            /**
+             * Encodes the specified DescriptorProto message. Does not implicitly {@link google.protobuf.DescriptorProto.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.DescriptorProto
+             * @static
+             * @param {google.protobuf.IDescriptorProto} message DescriptorProto message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DescriptorProto.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.name != null && message.hasOwnProperty("name"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
+                if (message.field != null && message.field.length)
+                    for (var i = 0; i < message.field.length; ++i)
+                        $root.google.protobuf.FieldDescriptorProto.encode(message.field[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                if (message.nestedType != null && message.nestedType.length)
+                    for (var i = 0; i < message.nestedType.length; ++i)
+                        $root.google.protobuf.DescriptorProto.encode(message.nestedType[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                if (message.enumType != null && message.enumType.length)
+                    for (var i = 0; i < message.enumType.length; ++i)
+                        $root.google.protobuf.EnumDescriptorProto.encode(message.enumType[i], writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                if (message.extensionRange != null && message.extensionRange.length)
+                    for (var i = 0; i < message.extensionRange.length; ++i)
+                        $root.google.protobuf.DescriptorProto.ExtensionRange.encode(message.extensionRange[i], writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+                if (message.extension != null && message.extension.length)
+                    for (var i = 0; i < message.extension.length; ++i)
+                        $root.google.protobuf.FieldDescriptorProto.encode(message.extension[i], writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
+                if (message.options != null && message.hasOwnProperty("options"))
+                    $root.google.protobuf.MessageOptions.encode(message.options, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+                if (message.oneofDecl != null && message.oneofDecl.length)
+                    for (var i = 0; i < message.oneofDecl.length; ++i)
+                        $root.google.protobuf.OneofDescriptorProto.encode(message.oneofDecl[i], writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
+                if (message.reservedRange != null && message.reservedRange.length)
+                    for (var i = 0; i < message.reservedRange.length; ++i)
+                        $root.google.protobuf.DescriptorProto.ReservedRange.encode(message.reservedRange[i], writer.uint32(/* id 9, wireType 2 =*/74).fork()).ldelim();
+                if (message.reservedName != null && message.reservedName.length)
+                    for (var i = 0; i < message.reservedName.length; ++i)
+                        writer.uint32(/* id 10, wireType 2 =*/82).string(message.reservedName[i]);
+                return writer;
+            };
+
+            /**
+             * Encodes the specified DescriptorProto message, length delimited. Does not implicitly {@link google.protobuf.DescriptorProto.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.DescriptorProto
+             * @static
+             * @param {google.protobuf.IDescriptorProto} message DescriptorProto message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DescriptorProto.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a DescriptorProto message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.DescriptorProto
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.DescriptorProto} DescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DescriptorProto.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.DescriptorProto();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.name = reader.string();
+                        break;
+                    case 2:
+                        if (!(message.field && message.field.length))
+                            message.field = [];
+                        message.field.push($root.google.protobuf.FieldDescriptorProto.decode(reader, reader.uint32()));
+                        break;
+                    case 6:
+                        if (!(message.extension && message.extension.length))
+                            message.extension = [];
+                        message.extension.push($root.google.protobuf.FieldDescriptorProto.decode(reader, reader.uint32()));
+                        break;
+                    case 3:
+                        if (!(message.nestedType && message.nestedType.length))
+                            message.nestedType = [];
+                        message.nestedType.push($root.google.protobuf.DescriptorProto.decode(reader, reader.uint32()));
+                        break;
+                    case 4:
+                        if (!(message.enumType && message.enumType.length))
+                            message.enumType = [];
+                        message.enumType.push($root.google.protobuf.EnumDescriptorProto.decode(reader, reader.uint32()));
+                        break;
+                    case 5:
+                        if (!(message.extensionRange && message.extensionRange.length))
+                            message.extensionRange = [];
+                        message.extensionRange.push($root.google.protobuf.DescriptorProto.ExtensionRange.decode(reader, reader.uint32()));
+                        break;
+                    case 8:
+                        if (!(message.oneofDecl && message.oneofDecl.length))
+                            message.oneofDecl = [];
+                        message.oneofDecl.push($root.google.protobuf.OneofDescriptorProto.decode(reader, reader.uint32()));
+                        break;
+                    case 7:
+                        message.options = $root.google.protobuf.MessageOptions.decode(reader, reader.uint32());
+                        break;
+                    case 9:
+                        if (!(message.reservedRange && message.reservedRange.length))
+                            message.reservedRange = [];
+                        message.reservedRange.push($root.google.protobuf.DescriptorProto.ReservedRange.decode(reader, reader.uint32()));
+                        break;
+                    case 10:
+                        if (!(message.reservedName && message.reservedName.length))
+                            message.reservedName = [];
+                        message.reservedName.push(reader.string());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a DescriptorProto message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.DescriptorProto
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.DescriptorProto} DescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DescriptorProto.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a DescriptorProto message.
+             * @function verify
+             * @memberof google.protobuf.DescriptorProto
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            DescriptorProto.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.name != null && message.hasOwnProperty("name"))
+                    if (!$util.isString(message.name))
+                        return "name: string expected";
+                if (message.field != null && message.hasOwnProperty("field")) {
+                    if (!Array.isArray(message.field))
+                        return "field: array expected";
+                    for (var i = 0; i < message.field.length; ++i) {
+                        var error = $root.google.protobuf.FieldDescriptorProto.verify(message.field[i]);
+                        if (error)
+                            return "field." + error;
+                    }
+                }
+                if (message.extension != null && message.hasOwnProperty("extension")) {
+                    if (!Array.isArray(message.extension))
+                        return "extension: array expected";
+                    for (var i = 0; i < message.extension.length; ++i) {
+                        error = $root.google.protobuf.FieldDescriptorProto.verify(message.extension[i]);
+                        if (error)
+                            return "extension." + error;
+                    }
+                }
+                if (message.nestedType != null && message.hasOwnProperty("nestedType")) {
+                    if (!Array.isArray(message.nestedType))
+                        return "nestedType: array expected";
+                    for (var i = 0; i < message.nestedType.length; ++i) {
+                        error = $root.google.protobuf.DescriptorProto.verify(message.nestedType[i]);
+                        if (error)
+                            return "nestedType." + error;
+                    }
+                }
+                if (message.enumType != null && message.hasOwnProperty("enumType")) {
+                    if (!Array.isArray(message.enumType))
+                        return "enumType: array expected";
+                    for (var i = 0; i < message.enumType.length; ++i) {
+                        error = $root.google.protobuf.EnumDescriptorProto.verify(message.enumType[i]);
+                        if (error)
+                            return "enumType." + error;
+                    }
+                }
+                if (message.extensionRange != null && message.hasOwnProperty("extensionRange")) {
+                    if (!Array.isArray(message.extensionRange))
+                        return "extensionRange: array expected";
+                    for (var i = 0; i < message.extensionRange.length; ++i) {
+                        error = $root.google.protobuf.DescriptorProto.ExtensionRange.verify(message.extensionRange[i]);
+                        if (error)
+                            return "extensionRange." + error;
+                    }
+                }
+                if (message.oneofDecl != null && message.hasOwnProperty("oneofDecl")) {
+                    if (!Array.isArray(message.oneofDecl))
+                        return "oneofDecl: array expected";
+                    for (var i = 0; i < message.oneofDecl.length; ++i) {
+                        error = $root.google.protobuf.OneofDescriptorProto.verify(message.oneofDecl[i]);
+                        if (error)
+                            return "oneofDecl." + error;
+                    }
+                }
+                if (message.options != null && message.hasOwnProperty("options")) {
+                    error = $root.google.protobuf.MessageOptions.verify(message.options);
+                    if (error)
+                        return "options." + error;
+                }
+                if (message.reservedRange != null && message.hasOwnProperty("reservedRange")) {
+                    if (!Array.isArray(message.reservedRange))
+                        return "reservedRange: array expected";
+                    for (var i = 0; i < message.reservedRange.length; ++i) {
+                        error = $root.google.protobuf.DescriptorProto.ReservedRange.verify(message.reservedRange[i]);
+                        if (error)
+                            return "reservedRange." + error;
+                    }
+                }
+                if (message.reservedName != null && message.hasOwnProperty("reservedName")) {
+                    if (!Array.isArray(message.reservedName))
+                        return "reservedName: array expected";
+                    for (var i = 0; i < message.reservedName.length; ++i)
+                        if (!$util.isString(message.reservedName[i]))
+                            return "reservedName: string[] expected";
+                }
+                return null;
+            };
+
+            /**
+             * Creates a DescriptorProto message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.DescriptorProto
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.DescriptorProto} DescriptorProto
+             */
+            DescriptorProto.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.DescriptorProto)
+                    return object;
+                var message = new $root.google.protobuf.DescriptorProto();
+                if (object.name != null)
+                    message.name = String(object.name);
+                if (object.field) {
+                    if (!Array.isArray(object.field))
+                        throw TypeError(".google.protobuf.DescriptorProto.field: array expected");
+                    message.field = [];
+                    for (var i = 0; i < object.field.length; ++i) {
+                        if (typeof object.field[i] !== "object")
+                            throw TypeError(".google.protobuf.DescriptorProto.field: object expected");
+                        message.field[i] = $root.google.protobuf.FieldDescriptorProto.fromObject(object.field[i]);
+                    }
+                }
+                if (object.extension) {
+                    if (!Array.isArray(object.extension))
+                        throw TypeError(".google.protobuf.DescriptorProto.extension: array expected");
+                    message.extension = [];
+                    for (var i = 0; i < object.extension.length; ++i) {
+                        if (typeof object.extension[i] !== "object")
+                            throw TypeError(".google.protobuf.DescriptorProto.extension: object expected");
+                        message.extension[i] = $root.google.protobuf.FieldDescriptorProto.fromObject(object.extension[i]);
+                    }
+                }
+                if (object.nestedType) {
+                    if (!Array.isArray(object.nestedType))
+                        throw TypeError(".google.protobuf.DescriptorProto.nestedType: array expected");
+                    message.nestedType = [];
+                    for (var i = 0; i < object.nestedType.length; ++i) {
+                        if (typeof object.nestedType[i] !== "object")
+                            throw TypeError(".google.protobuf.DescriptorProto.nestedType: object expected");
+                        message.nestedType[i] = $root.google.protobuf.DescriptorProto.fromObject(object.nestedType[i]);
+                    }
+                }
+                if (object.enumType) {
+                    if (!Array.isArray(object.enumType))
+                        throw TypeError(".google.protobuf.DescriptorProto.enumType: array expected");
+                    message.enumType = [];
+                    for (var i = 0; i < object.enumType.length; ++i) {
+                        if (typeof object.enumType[i] !== "object")
+                            throw TypeError(".google.protobuf.DescriptorProto.enumType: object expected");
+                        message.enumType[i] = $root.google.protobuf.EnumDescriptorProto.fromObject(object.enumType[i]);
+                    }
+                }
+                if (object.extensionRange) {
+                    if (!Array.isArray(object.extensionRange))
+                        throw TypeError(".google.protobuf.DescriptorProto.extensionRange: array expected");
+                    message.extensionRange = [];
+                    for (var i = 0; i < object.extensionRange.length; ++i) {
+                        if (typeof object.extensionRange[i] !== "object")
+                            throw TypeError(".google.protobuf.DescriptorProto.extensionRange: object expected");
+                        message.extensionRange[i] = $root.google.protobuf.DescriptorProto.ExtensionRange.fromObject(object.extensionRange[i]);
+                    }
+                }
+                if (object.oneofDecl) {
+                    if (!Array.isArray(object.oneofDecl))
+                        throw TypeError(".google.protobuf.DescriptorProto.oneofDecl: array expected");
+                    message.oneofDecl = [];
+                    for (var i = 0; i < object.oneofDecl.length; ++i) {
+                        if (typeof object.oneofDecl[i] !== "object")
+                            throw TypeError(".google.protobuf.DescriptorProto.oneofDecl: object expected");
+                        message.oneofDecl[i] = $root.google.protobuf.OneofDescriptorProto.fromObject(object.oneofDecl[i]);
+                    }
+                }
+                if (object.options != null) {
+                    if (typeof object.options !== "object")
+                        throw TypeError(".google.protobuf.DescriptorProto.options: object expected");
+                    message.options = $root.google.protobuf.MessageOptions.fromObject(object.options);
+                }
+                if (object.reservedRange) {
+                    if (!Array.isArray(object.reservedRange))
+                        throw TypeError(".google.protobuf.DescriptorProto.reservedRange: array expected");
+                    message.reservedRange = [];
+                    for (var i = 0; i < object.reservedRange.length; ++i) {
+                        if (typeof object.reservedRange[i] !== "object")
+                            throw TypeError(".google.protobuf.DescriptorProto.reservedRange: object expected");
+                        message.reservedRange[i] = $root.google.protobuf.DescriptorProto.ReservedRange.fromObject(object.reservedRange[i]);
+                    }
+                }
+                if (object.reservedName) {
+                    if (!Array.isArray(object.reservedName))
+                        throw TypeError(".google.protobuf.DescriptorProto.reservedName: array expected");
+                    message.reservedName = [];
+                    for (var i = 0; i < object.reservedName.length; ++i)
+                        message.reservedName[i] = String(object.reservedName[i]);
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a DescriptorProto message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.DescriptorProto
+             * @static
+             * @param {google.protobuf.DescriptorProto} message DescriptorProto
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            DescriptorProto.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults) {
+                    object.field = [];
+                    object.nestedType = [];
+                    object.enumType = [];
+                    object.extensionRange = [];
+                    object.extension = [];
+                    object.oneofDecl = [];
+                    object.reservedRange = [];
+                    object.reservedName = [];
+                }
+                if (options.defaults) {
+                    object.name = "";
+                    object.options = null;
+                }
+                if (message.name != null && message.hasOwnProperty("name"))
+                    object.name = message.name;
+                if (message.field && message.field.length) {
+                    object.field = [];
+                    for (var j = 0; j < message.field.length; ++j)
+                        object.field[j] = $root.google.protobuf.FieldDescriptorProto.toObject(message.field[j], options);
+                }
+                if (message.nestedType && message.nestedType.length) {
+                    object.nestedType = [];
+                    for (var j = 0; j < message.nestedType.length; ++j)
+                        object.nestedType[j] = $root.google.protobuf.DescriptorProto.toObject(message.nestedType[j], options);
+                }
+                if (message.enumType && message.enumType.length) {
+                    object.enumType = [];
+                    for (var j = 0; j < message.enumType.length; ++j)
+                        object.enumType[j] = $root.google.protobuf.EnumDescriptorProto.toObject(message.enumType[j], options);
+                }
+                if (message.extensionRange && message.extensionRange.length) {
+                    object.extensionRange = [];
+                    for (var j = 0; j < message.extensionRange.length; ++j)
+                        object.extensionRange[j] = $root.google.protobuf.DescriptorProto.ExtensionRange.toObject(message.extensionRange[j], options);
+                }
+                if (message.extension && message.extension.length) {
+                    object.extension = [];
+                    for (var j = 0; j < message.extension.length; ++j)
+                        object.extension[j] = $root.google.protobuf.FieldDescriptorProto.toObject(message.extension[j], options);
+                }
+                if (message.options != null && message.hasOwnProperty("options"))
+                    object.options = $root.google.protobuf.MessageOptions.toObject(message.options, options);
+                if (message.oneofDecl && message.oneofDecl.length) {
+                    object.oneofDecl = [];
+                    for (var j = 0; j < message.oneofDecl.length; ++j)
+                        object.oneofDecl[j] = $root.google.protobuf.OneofDescriptorProto.toObject(message.oneofDecl[j], options);
+                }
+                if (message.reservedRange && message.reservedRange.length) {
+                    object.reservedRange = [];
+                    for (var j = 0; j < message.reservedRange.length; ++j)
+                        object.reservedRange[j] = $root.google.protobuf.DescriptorProto.ReservedRange.toObject(message.reservedRange[j], options);
+                }
+                if (message.reservedName && message.reservedName.length) {
+                    object.reservedName = [];
+                    for (var j = 0; j < message.reservedName.length; ++j)
+                        object.reservedName[j] = message.reservedName[j];
+                }
+                return object;
+            };
+
+            /**
+             * Converts this DescriptorProto to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.DescriptorProto
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            DescriptorProto.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            DescriptorProto.ExtensionRange = (function() {
+
+                /**
+                 * Properties of an ExtensionRange.
+                 * @memberof google.protobuf.DescriptorProto
+                 * @interface IExtensionRange
+                 * @property {number} [start] ExtensionRange start
+                 * @property {number} [end] ExtensionRange end
+                 */
+
+                /**
+                 * Constructs a new ExtensionRange.
+                 * @memberof google.protobuf.DescriptorProto
+                 * @classdesc Represents an ExtensionRange.
+                 * @constructor
+                 * @param {google.protobuf.DescriptorProto.IExtensionRange=} [properties] Properties to set
+                 */
+                function ExtensionRange(properties) {
+                    if (properties)
+                        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null)
+                                this[keys[i]] = properties[keys[i]];
+                }
+
+                /**
+                 * ExtensionRange start.
+                 * @member {number}start
+                 * @memberof google.protobuf.DescriptorProto.ExtensionRange
+                 * @instance
+                 */
+                ExtensionRange.prototype.start = 0;
+
+                /**
+                 * ExtensionRange end.
+                 * @member {number}end
+                 * @memberof google.protobuf.DescriptorProto.ExtensionRange
+                 * @instance
+                 */
+                ExtensionRange.prototype.end = 0;
+
+                /**
+                 * Creates a new ExtensionRange instance using the specified properties.
+                 * @function create
+                 * @memberof google.protobuf.DescriptorProto.ExtensionRange
+                 * @static
+                 * @param {google.protobuf.DescriptorProto.IExtensionRange=} [properties] Properties to set
+                 * @returns {google.protobuf.DescriptorProto.ExtensionRange} ExtensionRange instance
+                 */
+                ExtensionRange.create = function create(properties) {
+                    return new ExtensionRange(properties);
+                };
+
+                /**
+                 * Encodes the specified ExtensionRange message. Does not implicitly {@link google.protobuf.DescriptorProto.ExtensionRange.verify|verify} messages.
+                 * @function encode
+                 * @memberof google.protobuf.DescriptorProto.ExtensionRange
+                 * @static
+                 * @param {google.protobuf.DescriptorProto.IExtensionRange} message ExtensionRange message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                ExtensionRange.encode = function encode(message, writer) {
+                    if (!writer)
+                        writer = $Writer.create();
+                    if (message.start != null && message.hasOwnProperty("start"))
+                        writer.uint32(/* id 1, wireType 0 =*/8).int32(message.start);
+                    if (message.end != null && message.hasOwnProperty("end"))
+                        writer.uint32(/* id 2, wireType 0 =*/16).int32(message.end);
+                    return writer;
+                };
+
+                /**
+                 * Encodes the specified ExtensionRange message, length delimited. Does not implicitly {@link google.protobuf.DescriptorProto.ExtensionRange.verify|verify} messages.
+                 * @function encodeDelimited
+                 * @memberof google.protobuf.DescriptorProto.ExtensionRange
+                 * @static
+                 * @param {google.protobuf.DescriptorProto.IExtensionRange} message ExtensionRange message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                ExtensionRange.encodeDelimited = function encodeDelimited(message, writer) {
+                    return this.encode(message, writer).ldelim();
+                };
+
+                /**
+                 * Decodes an ExtensionRange message from the specified reader or buffer.
+                 * @function decode
+                 * @memberof google.protobuf.DescriptorProto.ExtensionRange
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @param {number} [length] Message length if known beforehand
+                 * @returns {google.protobuf.DescriptorProto.ExtensionRange} ExtensionRange
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                ExtensionRange.decode = function decode(reader, length) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader.create(reader);
+                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.DescriptorProto.ExtensionRange();
+                    while (reader.pos < end) {
+                        var tag = reader.uint32();
+                        switch (tag >>> 3) {
+                        case 1:
+                            message.start = reader.int32();
+                            break;
+                        case 2:
+                            message.end = reader.int32();
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                        }
+                    }
+                    return message;
+                };
+
+                /**
+                 * Decodes an ExtensionRange message from the specified reader or buffer, length delimited.
+                 * @function decodeDelimited
+                 * @memberof google.protobuf.DescriptorProto.ExtensionRange
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @returns {google.protobuf.DescriptorProto.ExtensionRange} ExtensionRange
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                ExtensionRange.decodeDelimited = function decodeDelimited(reader) {
+                    if (!(reader instanceof $Reader))
+                        reader = new $Reader(reader);
+                    return this.decode(reader, reader.uint32());
+                };
+
+                /**
+                 * Verifies an ExtensionRange message.
+                 * @function verify
+                 * @memberof google.protobuf.DescriptorProto.ExtensionRange
+                 * @static
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                 */
+                ExtensionRange.verify = function verify(message) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    if (message.start != null && message.hasOwnProperty("start"))
+                        if (!$util.isInteger(message.start))
+                            return "start: integer expected";
+                    if (message.end != null && message.hasOwnProperty("end"))
+                        if (!$util.isInteger(message.end))
+                            return "end: integer expected";
+                    return null;
+                };
+
+                /**
+                 * Creates an ExtensionRange message from a plain object. Also converts values to their respective internal types.
+                 * @function fromObject
+                 * @memberof google.protobuf.DescriptorProto.ExtensionRange
+                 * @static
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {google.protobuf.DescriptorProto.ExtensionRange} ExtensionRange
+                 */
+                ExtensionRange.fromObject = function fromObject(object) {
+                    if (object instanceof $root.google.protobuf.DescriptorProto.ExtensionRange)
+                        return object;
+                    var message = new $root.google.protobuf.DescriptorProto.ExtensionRange();
+                    if (object.start != null)
+                        message.start = object.start | 0;
+                    if (object.end != null)
+                        message.end = object.end | 0;
+                    return message;
+                };
+
+                /**
+                 * Creates a plain object from an ExtensionRange message. Also converts values to other types if specified.
+                 * @function toObject
+                 * @memberof google.protobuf.DescriptorProto.ExtensionRange
+                 * @static
+                 * @param {google.protobuf.DescriptorProto.ExtensionRange} message ExtensionRange
+                 * @param {$protobuf.IConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                ExtensionRange.toObject = function toObject(message, options) {
+                    if (!options)
+                        options = {};
+                    var object = {};
+                    if (options.defaults) {
+                        object.start = 0;
+                        object.end = 0;
+                    }
+                    if (message.start != null && message.hasOwnProperty("start"))
+                        object.start = message.start;
+                    if (message.end != null && message.hasOwnProperty("end"))
+                        object.end = message.end;
+                    return object;
+                };
+
+                /**
+                 * Converts this ExtensionRange to JSON.
+                 * @function toJSON
+                 * @memberof google.protobuf.DescriptorProto.ExtensionRange
+                 * @instance
+                 * @returns {Object.<string,*>} JSON object
+                 */
+                ExtensionRange.prototype.toJSON = function toJSON() {
+                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                };
+
+                return ExtensionRange;
+            })();
+
+            DescriptorProto.ReservedRange = (function() {
+
+                /**
+                 * Properties of a ReservedRange.
+                 * @memberof google.protobuf.DescriptorProto
+                 * @interface IReservedRange
+                 * @property {number} [start] ReservedRange start
+                 * @property {number} [end] ReservedRange end
+                 */
+
+                /**
+                 * Constructs a new ReservedRange.
+                 * @memberof google.protobuf.DescriptorProto
+                 * @classdesc Represents a ReservedRange.
+                 * @constructor
+                 * @param {google.protobuf.DescriptorProto.IReservedRange=} [properties] Properties to set
+                 */
+                function ReservedRange(properties) {
+                    if (properties)
+                        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null)
+                                this[keys[i]] = properties[keys[i]];
+                }
+
+                /**
+                 * ReservedRange start.
+                 * @member {number}start
+                 * @memberof google.protobuf.DescriptorProto.ReservedRange
+                 * @instance
+                 */
+                ReservedRange.prototype.start = 0;
+
+                /**
+                 * ReservedRange end.
+                 * @member {number}end
+                 * @memberof google.protobuf.DescriptorProto.ReservedRange
+                 * @instance
+                 */
+                ReservedRange.prototype.end = 0;
+
+                /**
+                 * Creates a new ReservedRange instance using the specified properties.
+                 * @function create
+                 * @memberof google.protobuf.DescriptorProto.ReservedRange
+                 * @static
+                 * @param {google.protobuf.DescriptorProto.IReservedRange=} [properties] Properties to set
+                 * @returns {google.protobuf.DescriptorProto.ReservedRange} ReservedRange instance
+                 */
+                ReservedRange.create = function create(properties) {
+                    return new ReservedRange(properties);
+                };
+
+                /**
+                 * Encodes the specified ReservedRange message. Does not implicitly {@link google.protobuf.DescriptorProto.ReservedRange.verify|verify} messages.
+                 * @function encode
+                 * @memberof google.protobuf.DescriptorProto.ReservedRange
+                 * @static
+                 * @param {google.protobuf.DescriptorProto.IReservedRange} message ReservedRange message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                ReservedRange.encode = function encode(message, writer) {
+                    if (!writer)
+                        writer = $Writer.create();
+                    if (message.start != null && message.hasOwnProperty("start"))
+                        writer.uint32(/* id 1, wireType 0 =*/8).int32(message.start);
+                    if (message.end != null && message.hasOwnProperty("end"))
+                        writer.uint32(/* id 2, wireType 0 =*/16).int32(message.end);
+                    return writer;
+                };
+
+                /**
+                 * Encodes the specified ReservedRange message, length delimited. Does not implicitly {@link google.protobuf.DescriptorProto.ReservedRange.verify|verify} messages.
+                 * @function encodeDelimited
+                 * @memberof google.protobuf.DescriptorProto.ReservedRange
+                 * @static
+                 * @param {google.protobuf.DescriptorProto.IReservedRange} message ReservedRange message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                ReservedRange.encodeDelimited = function encodeDelimited(message, writer) {
+                    return this.encode(message, writer).ldelim();
+                };
+
+                /**
+                 * Decodes a ReservedRange message from the specified reader or buffer.
+                 * @function decode
+                 * @memberof google.protobuf.DescriptorProto.ReservedRange
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @param {number} [length] Message length if known beforehand
+                 * @returns {google.protobuf.DescriptorProto.ReservedRange} ReservedRange
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                ReservedRange.decode = function decode(reader, length) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader.create(reader);
+                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.DescriptorProto.ReservedRange();
+                    while (reader.pos < end) {
+                        var tag = reader.uint32();
+                        switch (tag >>> 3) {
+                        case 1:
+                            message.start = reader.int32();
+                            break;
+                        case 2:
+                            message.end = reader.int32();
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                        }
+                    }
+                    return message;
+                };
+
+                /**
+                 * Decodes a ReservedRange message from the specified reader or buffer, length delimited.
+                 * @function decodeDelimited
+                 * @memberof google.protobuf.DescriptorProto.ReservedRange
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @returns {google.protobuf.DescriptorProto.ReservedRange} ReservedRange
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                ReservedRange.decodeDelimited = function decodeDelimited(reader) {
+                    if (!(reader instanceof $Reader))
+                        reader = new $Reader(reader);
+                    return this.decode(reader, reader.uint32());
+                };
+
+                /**
+                 * Verifies a ReservedRange message.
+                 * @function verify
+                 * @memberof google.protobuf.DescriptorProto.ReservedRange
+                 * @static
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                 */
+                ReservedRange.verify = function verify(message) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    if (message.start != null && message.hasOwnProperty("start"))
+                        if (!$util.isInteger(message.start))
+                            return "start: integer expected";
+                    if (message.end != null && message.hasOwnProperty("end"))
+                        if (!$util.isInteger(message.end))
+                            return "end: integer expected";
+                    return null;
+                };
+
+                /**
+                 * Creates a ReservedRange message from a plain object. Also converts values to their respective internal types.
+                 * @function fromObject
+                 * @memberof google.protobuf.DescriptorProto.ReservedRange
+                 * @static
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {google.protobuf.DescriptorProto.ReservedRange} ReservedRange
+                 */
+                ReservedRange.fromObject = function fromObject(object) {
+                    if (object instanceof $root.google.protobuf.DescriptorProto.ReservedRange)
+                        return object;
+                    var message = new $root.google.protobuf.DescriptorProto.ReservedRange();
+                    if (object.start != null)
+                        message.start = object.start | 0;
+                    if (object.end != null)
+                        message.end = object.end | 0;
+                    return message;
+                };
+
+                /**
+                 * Creates a plain object from a ReservedRange message. Also converts values to other types if specified.
+                 * @function toObject
+                 * @memberof google.protobuf.DescriptorProto.ReservedRange
+                 * @static
+                 * @param {google.protobuf.DescriptorProto.ReservedRange} message ReservedRange
+                 * @param {$protobuf.IConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                ReservedRange.toObject = function toObject(message, options) {
+                    if (!options)
+                        options = {};
+                    var object = {};
+                    if (options.defaults) {
+                        object.start = 0;
+                        object.end = 0;
+                    }
+                    if (message.start != null && message.hasOwnProperty("start"))
+                        object.start = message.start;
+                    if (message.end != null && message.hasOwnProperty("end"))
+                        object.end = message.end;
+                    return object;
+                };
+
+                /**
+                 * Converts this ReservedRange to JSON.
+                 * @function toJSON
+                 * @memberof google.protobuf.DescriptorProto.ReservedRange
+                 * @instance
+                 * @returns {Object.<string,*>} JSON object
+                 */
+                ReservedRange.prototype.toJSON = function toJSON() {
+                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                };
+
+                return ReservedRange;
+            })();
+
+            return DescriptorProto;
+        })();
+
+        protobuf.FieldDescriptorProto = (function() {
+
+            /**
+             * Properties of a FieldDescriptorProto.
+             * @memberof google.protobuf
+             * @interface IFieldDescriptorProto
+             * @property {string} [name] FieldDescriptorProto name
+             * @property {number} [number] FieldDescriptorProto number
+             * @property {google.protobuf.FieldDescriptorProto.Label} [label] FieldDescriptorProto label
+             * @property {google.protobuf.FieldDescriptorProto.Type} [type] FieldDescriptorProto type
+             * @property {string} [typeName] FieldDescriptorProto typeName
+             * @property {string} [extendee] FieldDescriptorProto extendee
+             * @property {string} [defaultValue] FieldDescriptorProto defaultValue
+             * @property {number} [oneofIndex] FieldDescriptorProto oneofIndex
+             * @property {string} [jsonName] FieldDescriptorProto jsonName
+             * @property {google.protobuf.IFieldOptions} [options] FieldDescriptorProto options
+             */
+
+            /**
+             * Constructs a new FieldDescriptorProto.
+             * @memberof google.protobuf
+             * @classdesc Represents a FieldDescriptorProto.
+             * @constructor
+             * @param {google.protobuf.IFieldDescriptorProto=} [properties] Properties to set
+             */
+            function FieldDescriptorProto(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * FieldDescriptorProto name.
+             * @member {string}name
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @instance
+             */
+            FieldDescriptorProto.prototype.name = "";
+
+            /**
+             * FieldDescriptorProto number.
+             * @member {number}number
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @instance
+             */
+            FieldDescriptorProto.prototype.number = 0;
+
+            /**
+             * FieldDescriptorProto label.
+             * @member {google.protobuf.FieldDescriptorProto.Label}label
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @instance
+             */
+            FieldDescriptorProto.prototype.label = 1;
+
+            /**
+             * FieldDescriptorProto type.
+             * @member {google.protobuf.FieldDescriptorProto.Type}type
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @instance
+             */
+            FieldDescriptorProto.prototype.type = 1;
+
+            /**
+             * FieldDescriptorProto typeName.
+             * @member {string}typeName
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @instance
+             */
+            FieldDescriptorProto.prototype.typeName = "";
+
+            /**
+             * FieldDescriptorProto extendee.
+             * @member {string}extendee
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @instance
+             */
+            FieldDescriptorProto.prototype.extendee = "";
+
+            /**
+             * FieldDescriptorProto defaultValue.
+             * @member {string}defaultValue
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @instance
+             */
+            FieldDescriptorProto.prototype.defaultValue = "";
+
+            /**
+             * FieldDescriptorProto oneofIndex.
+             * @member {number}oneofIndex
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @instance
+             */
+            FieldDescriptorProto.prototype.oneofIndex = 0;
+
+            /**
+             * FieldDescriptorProto jsonName.
+             * @member {string}jsonName
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @instance
+             */
+            FieldDescriptorProto.prototype.jsonName = "";
+
+            /**
+             * FieldDescriptorProto options.
+             * @member {(google.protobuf.IFieldOptions|null|undefined)}options
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @instance
+             */
+            FieldDescriptorProto.prototype.options = null;
+
+            /**
+             * Creates a new FieldDescriptorProto instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @static
+             * @param {google.protobuf.IFieldDescriptorProto=} [properties] Properties to set
+             * @returns {google.protobuf.FieldDescriptorProto} FieldDescriptorProto instance
+             */
+            FieldDescriptorProto.create = function create(properties) {
+                return new FieldDescriptorProto(properties);
+            };
+
+            /**
+             * Encodes the specified FieldDescriptorProto message. Does not implicitly {@link google.protobuf.FieldDescriptorProto.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @static
+             * @param {google.protobuf.IFieldDescriptorProto} message FieldDescriptorProto message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            FieldDescriptorProto.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.name != null && message.hasOwnProperty("name"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
+                if (message.extendee != null && message.hasOwnProperty("extendee"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.extendee);
+                if (message.number != null && message.hasOwnProperty("number"))
+                    writer.uint32(/* id 3, wireType 0 =*/24).int32(message.number);
+                if (message.label != null && message.hasOwnProperty("label"))
+                    writer.uint32(/* id 4, wireType 0 =*/32).int32(message.label);
+                if (message.type != null && message.hasOwnProperty("type"))
+                    writer.uint32(/* id 5, wireType 0 =*/40).int32(message.type);
+                if (message.typeName != null && message.hasOwnProperty("typeName"))
+                    writer.uint32(/* id 6, wireType 2 =*/50).string(message.typeName);
+                if (message.defaultValue != null && message.hasOwnProperty("defaultValue"))
+                    writer.uint32(/* id 7, wireType 2 =*/58).string(message.defaultValue);
+                if (message.options != null && message.hasOwnProperty("options"))
+                    $root.google.protobuf.FieldOptions.encode(message.options, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
+                if (message.oneofIndex != null && message.hasOwnProperty("oneofIndex"))
+                    writer.uint32(/* id 9, wireType 0 =*/72).int32(message.oneofIndex);
+                if (message.jsonName != null && message.hasOwnProperty("jsonName"))
+                    writer.uint32(/* id 10, wireType 2 =*/82).string(message.jsonName);
+                return writer;
+            };
+
+            /**
+             * Encodes the specified FieldDescriptorProto message, length delimited. Does not implicitly {@link google.protobuf.FieldDescriptorProto.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @static
+             * @param {google.protobuf.IFieldDescriptorProto} message FieldDescriptorProto message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            FieldDescriptorProto.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a FieldDescriptorProto message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.FieldDescriptorProto} FieldDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            FieldDescriptorProto.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.FieldDescriptorProto();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.name = reader.string();
+                        break;
+                    case 3:
+                        message.number = reader.int32();
+                        break;
+                    case 4:
+                        message.label = reader.int32();
+                        break;
+                    case 5:
+                        message.type = reader.int32();
+                        break;
+                    case 6:
+                        message.typeName = reader.string();
+                        break;
+                    case 2:
+                        message.extendee = reader.string();
+                        break;
+                    case 7:
+                        message.defaultValue = reader.string();
+                        break;
+                    case 9:
+                        message.oneofIndex = reader.int32();
+                        break;
+                    case 10:
+                        message.jsonName = reader.string();
+                        break;
+                    case 8:
+                        message.options = $root.google.protobuf.FieldOptions.decode(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a FieldDescriptorProto message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.FieldDescriptorProto} FieldDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            FieldDescriptorProto.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a FieldDescriptorProto message.
+             * @function verify
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            FieldDescriptorProto.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.name != null && message.hasOwnProperty("name"))
+                    if (!$util.isString(message.name))
+                        return "name: string expected";
+                if (message.number != null && message.hasOwnProperty("number"))
+                    if (!$util.isInteger(message.number))
+                        return "number: integer expected";
+                if (message.label != null && message.hasOwnProperty("label"))
+                    switch (message.label) {
+                    default:
+                        return "label: enum value expected";
+                    case 1:
+                    case 2:
+                    case 3:
+                        break;
+                    }
+                if (message.type != null && message.hasOwnProperty("type"))
+                    switch (message.type) {
+                    default:
+                        return "type: enum value expected";
+                    case 1:
+                    case 2:
+                    case 3:
+                    case 4:
+                    case 5:
+                    case 6:
+                    case 7:
+                    case 8:
+                    case 9:
+                    case 10:
+                    case 11:
+                    case 12:
+                    case 13:
+                    case 14:
+                    case 15:
+                    case 16:
+                    case 17:
+                    case 18:
+                        break;
+                    }
+                if (message.typeName != null && message.hasOwnProperty("typeName"))
+                    if (!$util.isString(message.typeName))
+                        return "typeName: string expected";
+                if (message.extendee != null && message.hasOwnProperty("extendee"))
+                    if (!$util.isString(message.extendee))
+                        return "extendee: string expected";
+                if (message.defaultValue != null && message.hasOwnProperty("defaultValue"))
+                    if (!$util.isString(message.defaultValue))
+                        return "defaultValue: string expected";
+                if (message.oneofIndex != null && message.hasOwnProperty("oneofIndex"))
+                    if (!$util.isInteger(message.oneofIndex))
+                        return "oneofIndex: integer expected";
+                if (message.jsonName != null && message.hasOwnProperty("jsonName"))
+                    if (!$util.isString(message.jsonName))
+                        return "jsonName: string expected";
+                if (message.options != null && message.hasOwnProperty("options")) {
+                    var error = $root.google.protobuf.FieldOptions.verify(message.options);
+                    if (error)
+                        return "options." + error;
+                }
+                return null;
+            };
+
+            /**
+             * Creates a FieldDescriptorProto message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.FieldDescriptorProto} FieldDescriptorProto
+             */
+            FieldDescriptorProto.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.FieldDescriptorProto)
+                    return object;
+                var message = new $root.google.protobuf.FieldDescriptorProto();
+                if (object.name != null)
+                    message.name = String(object.name);
+                if (object.number != null)
+                    message.number = object.number | 0;
+                switch (object.label) {
+                case "LABEL_OPTIONAL":
+                case 1:
+                    message.label = 1;
+                    break;
+                case "LABEL_REQUIRED":
+                case 2:
+                    message.label = 2;
+                    break;
+                case "LABEL_REPEATED":
+                case 3:
+                    message.label = 3;
+                    break;
+                }
+                switch (object.type) {
+                case "TYPE_DOUBLE":
+                case 1:
+                    message.type = 1;
+                    break;
+                case "TYPE_FLOAT":
+                case 2:
+                    message.type = 2;
+                    break;
+                case "TYPE_INT64":
+                case 3:
+                    message.type = 3;
+                    break;
+                case "TYPE_UINT64":
+                case 4:
+                    message.type = 4;
+                    break;
+                case "TYPE_INT32":
+                case 5:
+                    message.type = 5;
+                    break;
+                case "TYPE_FIXED64":
+                case 6:
+                    message.type = 6;
+                    break;
+                case "TYPE_FIXED32":
+                case 7:
+                    message.type = 7;
+                    break;
+                case "TYPE_BOOL":
+                case 8:
+                    message.type = 8;
+                    break;
+                case "TYPE_STRING":
+                case 9:
+                    message.type = 9;
+                    break;
+                case "TYPE_GROUP":
+                case 10:
+                    message.type = 10;
+                    break;
+                case "TYPE_MESSAGE":
+                case 11:
+                    message.type = 11;
+                    break;
+                case "TYPE_BYTES":
+                case 12:
+                    message.type = 12;
+                    break;
+                case "TYPE_UINT32":
+                case 13:
+                    message.type = 13;
+                    break;
+                case "TYPE_ENUM":
+                case 14:
+                    message.type = 14;
+                    break;
+                case "TYPE_SFIXED32":
+                case 15:
+                    message.type = 15;
+                    break;
+                case "TYPE_SFIXED64":
+                case 16:
+                    message.type = 16;
+                    break;
+                case "TYPE_SINT32":
+                case 17:
+                    message.type = 17;
+                    break;
+                case "TYPE_SINT64":
+                case 18:
+                    message.type = 18;
+                    break;
+                }
+                if (object.typeName != null)
+                    message.typeName = String(object.typeName);
+                if (object.extendee != null)
+                    message.extendee = String(object.extendee);
+                if (object.defaultValue != null)
+                    message.defaultValue = String(object.defaultValue);
+                if (object.oneofIndex != null)
+                    message.oneofIndex = object.oneofIndex | 0;
+                if (object.jsonName != null)
+                    message.jsonName = String(object.jsonName);
+                if (object.options != null) {
+                    if (typeof object.options !== "object")
+                        throw TypeError(".google.protobuf.FieldDescriptorProto.options: object expected");
+                    message.options = $root.google.protobuf.FieldOptions.fromObject(object.options);
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a FieldDescriptorProto message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @static
+             * @param {google.protobuf.FieldDescriptorProto} message FieldDescriptorProto
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            FieldDescriptorProto.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.name = "";
+                    object.extendee = "";
+                    object.number = 0;
+                    object.label = options.enums === String ? "LABEL_OPTIONAL" : 1;
+                    object.type = options.enums === String ? "TYPE_DOUBLE" : 1;
+                    object.typeName = "";
+                    object.defaultValue = "";
+                    object.options = null;
+                    object.oneofIndex = 0;
+                    object.jsonName = "";
+                }
+                if (message.name != null && message.hasOwnProperty("name"))
+                    object.name = message.name;
+                if (message.extendee != null && message.hasOwnProperty("extendee"))
+                    object.extendee = message.extendee;
+                if (message.number != null && message.hasOwnProperty("number"))
+                    object.number = message.number;
+                if (message.label != null && message.hasOwnProperty("label"))
+                    object.label = options.enums === String ? $root.google.protobuf.FieldDescriptorProto.Label[message.label] : message.label;
+                if (message.type != null && message.hasOwnProperty("type"))
+                    object.type = options.enums === String ? $root.google.protobuf.FieldDescriptorProto.Type[message.type] : message.type;
+                if (message.typeName != null && message.hasOwnProperty("typeName"))
+                    object.typeName = message.typeName;
+                if (message.defaultValue != null && message.hasOwnProperty("defaultValue"))
+                    object.defaultValue = message.defaultValue;
+                if (message.options != null && message.hasOwnProperty("options"))
+                    object.options = $root.google.protobuf.FieldOptions.toObject(message.options, options);
+                if (message.oneofIndex != null && message.hasOwnProperty("oneofIndex"))
+                    object.oneofIndex = message.oneofIndex;
+                if (message.jsonName != null && message.hasOwnProperty("jsonName"))
+                    object.jsonName = message.jsonName;
+                return object;
+            };
+
+            /**
+             * Converts this FieldDescriptorProto to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.FieldDescriptorProto
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            FieldDescriptorProto.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            /**
+             * Type enum.
+             * @enum {string}
+             * @property {number} TYPE_DOUBLE=1 TYPE_DOUBLE value
+             * @property {number} TYPE_FLOAT=2 TYPE_FLOAT value
+             * @property {number} TYPE_INT64=3 TYPE_INT64 value
+             * @property {number} TYPE_UINT64=4 TYPE_UINT64 value
+             * @property {number} TYPE_INT32=5 TYPE_INT32 value
+             * @property {number} TYPE_FIXED64=6 TYPE_FIXED64 value
+             * @property {number} TYPE_FIXED32=7 TYPE_FIXED32 value
+             * @property {number} TYPE_BOOL=8 TYPE_BOOL value
+             * @property {number} TYPE_STRING=9 TYPE_STRING value
+             * @property {number} TYPE_GROUP=10 TYPE_GROUP value
+             * @property {number} TYPE_MESSAGE=11 TYPE_MESSAGE value
+             * @property {number} TYPE_BYTES=12 TYPE_BYTES value
+             * @property {number} TYPE_UINT32=13 TYPE_UINT32 value
+             * @property {number} TYPE_ENUM=14 TYPE_ENUM value
+             * @property {number} TYPE_SFIXED32=15 TYPE_SFIXED32 value
+             * @property {number} TYPE_SFIXED64=16 TYPE_SFIXED64 value
+             * @property {number} TYPE_SINT32=17 TYPE_SINT32 value
+             * @property {number} TYPE_SINT64=18 TYPE_SINT64 value
+             */
+            FieldDescriptorProto.Type = (function() {
+                var valuesById = {}, values = Object.create(valuesById);
+                values[valuesById[1] = "TYPE_DOUBLE"] = 1;
+                values[valuesById[2] = "TYPE_FLOAT"] = 2;
+                values[valuesById[3] = "TYPE_INT64"] = 3;
+                values[valuesById[4] = "TYPE_UINT64"] = 4;
+                values[valuesById[5] = "TYPE_INT32"] = 5;
+                values[valuesById[6] = "TYPE_FIXED64"] = 6;
+                values[valuesById[7] = "TYPE_FIXED32"] = 7;
+                values[valuesById[8] = "TYPE_BOOL"] = 8;
+                values[valuesById[9] = "TYPE_STRING"] = 9;
+                values[valuesById[10] = "TYPE_GROUP"] = 10;
+                values[valuesById[11] = "TYPE_MESSAGE"] = 11;
+                values[valuesById[12] = "TYPE_BYTES"] = 12;
+                values[valuesById[13] = "TYPE_UINT32"] = 13;
+                values[valuesById[14] = "TYPE_ENUM"] = 14;
+                values[valuesById[15] = "TYPE_SFIXED32"] = 15;
+                values[valuesById[16] = "TYPE_SFIXED64"] = 16;
+                values[valuesById[17] = "TYPE_SINT32"] = 17;
+                values[valuesById[18] = "TYPE_SINT64"] = 18;
+                return values;
+            })();
+
+            /**
+             * Label enum.
+             * @enum {string}
+             * @property {number} LABEL_OPTIONAL=1 LABEL_OPTIONAL value
+             * @property {number} LABEL_REQUIRED=2 LABEL_REQUIRED value
+             * @property {number} LABEL_REPEATED=3 LABEL_REPEATED value
+             */
+            FieldDescriptorProto.Label = (function() {
+                var valuesById = {}, values = Object.create(valuesById);
+                values[valuesById[1] = "LABEL_OPTIONAL"] = 1;
+                values[valuesById[2] = "LABEL_REQUIRED"] = 2;
+                values[valuesById[3] = "LABEL_REPEATED"] = 3;
+                return values;
+            })();
+
+            return FieldDescriptorProto;
+        })();
+
+        protobuf.OneofDescriptorProto = (function() {
+
+            /**
+             * Properties of an OneofDescriptorProto.
+             * @memberof google.protobuf
+             * @interface IOneofDescriptorProto
+             * @property {string} [name] OneofDescriptorProto name
+             * @property {google.protobuf.IOneofOptions} [options] OneofDescriptorProto options
+             */
+
+            /**
+             * Constructs a new OneofDescriptorProto.
+             * @memberof google.protobuf
+             * @classdesc Represents an OneofDescriptorProto.
+             * @constructor
+             * @param {google.protobuf.IOneofDescriptorProto=} [properties] Properties to set
+             */
+            function OneofDescriptorProto(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * OneofDescriptorProto name.
+             * @member {string}name
+             * @memberof google.protobuf.OneofDescriptorProto
+             * @instance
+             */
+            OneofDescriptorProto.prototype.name = "";
+
+            /**
+             * OneofDescriptorProto options.
+             * @member {(google.protobuf.IOneofOptions|null|undefined)}options
+             * @memberof google.protobuf.OneofDescriptorProto
+             * @instance
+             */
+            OneofDescriptorProto.prototype.options = null;
+
+            /**
+             * Creates a new OneofDescriptorProto instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.OneofDescriptorProto
+             * @static
+             * @param {google.protobuf.IOneofDescriptorProto=} [properties] Properties to set
+             * @returns {google.protobuf.OneofDescriptorProto} OneofDescriptorProto instance
+             */
+            OneofDescriptorProto.create = function create(properties) {
+                return new OneofDescriptorProto(properties);
+            };
+
+            /**
+             * Encodes the specified OneofDescriptorProto message. Does not implicitly {@link google.protobuf.OneofDescriptorProto.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.OneofDescriptorProto
+             * @static
+             * @param {google.protobuf.IOneofDescriptorProto} message OneofDescriptorProto message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            OneofDescriptorProto.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.name != null && message.hasOwnProperty("name"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
+                if (message.options != null && message.hasOwnProperty("options"))
+                    $root.google.protobuf.OneofOptions.encode(message.options, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified OneofDescriptorProto message, length delimited. Does not implicitly {@link google.protobuf.OneofDescriptorProto.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.OneofDescriptorProto
+             * @static
+             * @param {google.protobuf.IOneofDescriptorProto} message OneofDescriptorProto message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            OneofDescriptorProto.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes an OneofDescriptorProto message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.OneofDescriptorProto
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.OneofDescriptorProto} OneofDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            OneofDescriptorProto.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.OneofDescriptorProto();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.name = reader.string();
+                        break;
+                    case 2:
+                        message.options = $root.google.protobuf.OneofOptions.decode(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes an OneofDescriptorProto message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.OneofDescriptorProto
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.OneofDescriptorProto} OneofDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            OneofDescriptorProto.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies an OneofDescriptorProto message.
+             * @function verify
+             * @memberof google.protobuf.OneofDescriptorProto
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            OneofDescriptorProto.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.name != null && message.hasOwnProperty("name"))
+                    if (!$util.isString(message.name))
+                        return "name: string expected";
+                if (message.options != null && message.hasOwnProperty("options")) {
+                    var error = $root.google.protobuf.OneofOptions.verify(message.options);
+                    if (error)
+                        return "options." + error;
+                }
+                return null;
+            };
+
+            /**
+             * Creates an OneofDescriptorProto message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.OneofDescriptorProto
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.OneofDescriptorProto} OneofDescriptorProto
+             */
+            OneofDescriptorProto.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.OneofDescriptorProto)
+                    return object;
+                var message = new $root.google.protobuf.OneofDescriptorProto();
+                if (object.name != null)
+                    message.name = String(object.name);
+                if (object.options != null) {
+                    if (typeof object.options !== "object")
+                        throw TypeError(".google.protobuf.OneofDescriptorProto.options: object expected");
+                    message.options = $root.google.protobuf.OneofOptions.fromObject(object.options);
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from an OneofDescriptorProto message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.OneofDescriptorProto
+             * @static
+             * @param {google.protobuf.OneofDescriptorProto} message OneofDescriptorProto
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            OneofDescriptorProto.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.name = "";
+                    object.options = null;
+                }
+                if (message.name != null && message.hasOwnProperty("name"))
+                    object.name = message.name;
+                if (message.options != null && message.hasOwnProperty("options"))
+                    object.options = $root.google.protobuf.OneofOptions.toObject(message.options, options);
+                return object;
+            };
+
+            /**
+             * Converts this OneofDescriptorProto to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.OneofDescriptorProto
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            OneofDescriptorProto.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return OneofDescriptorProto;
+        })();
+
+        protobuf.EnumDescriptorProto = (function() {
+
+            /**
+             * Properties of an EnumDescriptorProto.
+             * @memberof google.protobuf
+             * @interface IEnumDescriptorProto
+             * @property {string} [name] EnumDescriptorProto name
+             * @property {Array.<google.protobuf.IEnumValueDescriptorProto>} [value] EnumDescriptorProto value
+             * @property {google.protobuf.IEnumOptions} [options] EnumDescriptorProto options
+             */
+
+            /**
+             * Constructs a new EnumDescriptorProto.
+             * @memberof google.protobuf
+             * @classdesc Represents an EnumDescriptorProto.
+             * @constructor
+             * @param {google.protobuf.IEnumDescriptorProto=} [properties] Properties to set
+             */
+            function EnumDescriptorProto(properties) {
+                this.value = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * EnumDescriptorProto name.
+             * @member {string}name
+             * @memberof google.protobuf.EnumDescriptorProto
+             * @instance
+             */
+            EnumDescriptorProto.prototype.name = "";
+
+            /**
+             * EnumDescriptorProto value.
+             * @member {Array.<google.protobuf.IEnumValueDescriptorProto>}value
+             * @memberof google.protobuf.EnumDescriptorProto
+             * @instance
+             */
+            EnumDescriptorProto.prototype.value = $util.emptyArray;
+
+            /**
+             * EnumDescriptorProto options.
+             * @member {(google.protobuf.IEnumOptions|null|undefined)}options
+             * @memberof google.protobuf.EnumDescriptorProto
+             * @instance
+             */
+            EnumDescriptorProto.prototype.options = null;
+
+            /**
+             * Creates a new EnumDescriptorProto instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.EnumDescriptorProto
+             * @static
+             * @param {google.protobuf.IEnumDescriptorProto=} [properties] Properties to set
+             * @returns {google.protobuf.EnumDescriptorProto} EnumDescriptorProto instance
+             */
+            EnumDescriptorProto.create = function create(properties) {
+                return new EnumDescriptorProto(properties);
+            };
+
+            /**
+             * Encodes the specified EnumDescriptorProto message. Does not implicitly {@link google.protobuf.EnumDescriptorProto.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.EnumDescriptorProto
+             * @static
+             * @param {google.protobuf.IEnumDescriptorProto} message EnumDescriptorProto message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            EnumDescriptorProto.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.name != null && message.hasOwnProperty("name"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
+                if (message.value != null && message.value.length)
+                    for (var i = 0; i < message.value.length; ++i)
+                        $root.google.protobuf.EnumValueDescriptorProto.encode(message.value[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                if (message.options != null && message.hasOwnProperty("options"))
+                    $root.google.protobuf.EnumOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified EnumDescriptorProto message, length delimited. Does not implicitly {@link google.protobuf.EnumDescriptorProto.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.EnumDescriptorProto
+             * @static
+             * @param {google.protobuf.IEnumDescriptorProto} message EnumDescriptorProto message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            EnumDescriptorProto.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes an EnumDescriptorProto message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.EnumDescriptorProto
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.EnumDescriptorProto} EnumDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            EnumDescriptorProto.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.EnumDescriptorProto();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.name = reader.string();
+                        break;
+                    case 2:
+                        if (!(message.value && message.value.length))
+                            message.value = [];
+                        message.value.push($root.google.protobuf.EnumValueDescriptorProto.decode(reader, reader.uint32()));
+                        break;
+                    case 3:
+                        message.options = $root.google.protobuf.EnumOptions.decode(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes an EnumDescriptorProto message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.EnumDescriptorProto
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.EnumDescriptorProto} EnumDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            EnumDescriptorProto.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies an EnumDescriptorProto message.
+             * @function verify
+             * @memberof google.protobuf.EnumDescriptorProto
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            EnumDescriptorProto.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.name != null && message.hasOwnProperty("name"))
+                    if (!$util.isString(message.name))
+                        return "name: string expected";
+                if (message.value != null && message.hasOwnProperty("value")) {
+                    if (!Array.isArray(message.value))
+                        return "value: array expected";
+                    for (var i = 0; i < message.value.length; ++i) {
+                        var error = $root.google.protobuf.EnumValueDescriptorProto.verify(message.value[i]);
+                        if (error)
+                            return "value." + error;
+                    }
+                }
+                if (message.options != null && message.hasOwnProperty("options")) {
+                    error = $root.google.protobuf.EnumOptions.verify(message.options);
+                    if (error)
+                        return "options." + error;
+                }
+                return null;
+            };
+
+            /**
+             * Creates an EnumDescriptorProto message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.EnumDescriptorProto
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.EnumDescriptorProto} EnumDescriptorProto
+             */
+            EnumDescriptorProto.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.EnumDescriptorProto)
+                    return object;
+                var message = new $root.google.protobuf.EnumDescriptorProto();
+                if (object.name != null)
+                    message.name = String(object.name);
+                if (object.value) {
+                    if (!Array.isArray(object.value))
+                        throw TypeError(".google.protobuf.EnumDescriptorProto.value: array expected");
+                    message.value = [];
+                    for (var i = 0; i < object.value.length; ++i) {
+                        if (typeof object.value[i] !== "object")
+                            throw TypeError(".google.protobuf.EnumDescriptorProto.value: object expected");
+                        message.value[i] = $root.google.protobuf.EnumValueDescriptorProto.fromObject(object.value[i]);
+                    }
+                }
+                if (object.options != null) {
+                    if (typeof object.options !== "object")
+                        throw TypeError(".google.protobuf.EnumDescriptorProto.options: object expected");
+                    message.options = $root.google.protobuf.EnumOptions.fromObject(object.options);
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from an EnumDescriptorProto message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.EnumDescriptorProto
+             * @static
+             * @param {google.protobuf.EnumDescriptorProto} message EnumDescriptorProto
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            EnumDescriptorProto.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.value = [];
+                if (options.defaults) {
+                    object.name = "";
+                    object.options = null;
+                }
+                if (message.name != null && message.hasOwnProperty("name"))
+                    object.name = message.name;
+                if (message.value && message.value.length) {
+                    object.value = [];
+                    for (var j = 0; j < message.value.length; ++j)
+                        object.value[j] = $root.google.protobuf.EnumValueDescriptorProto.toObject(message.value[j], options);
+                }
+                if (message.options != null && message.hasOwnProperty("options"))
+                    object.options = $root.google.protobuf.EnumOptions.toObject(message.options, options);
+                return object;
+            };
+
+            /**
+             * Converts this EnumDescriptorProto to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.EnumDescriptorProto
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            EnumDescriptorProto.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return EnumDescriptorProto;
+        })();
+
+        protobuf.EnumValueDescriptorProto = (function() {
+
+            /**
+             * Properties of an EnumValueDescriptorProto.
+             * @memberof google.protobuf
+             * @interface IEnumValueDescriptorProto
+             * @property {string} [name] EnumValueDescriptorProto name
+             * @property {number} [number] EnumValueDescriptorProto number
+             * @property {google.protobuf.IEnumValueOptions} [options] EnumValueDescriptorProto options
+             */
+
+            /**
+             * Constructs a new EnumValueDescriptorProto.
+             * @memberof google.protobuf
+             * @classdesc Represents an EnumValueDescriptorProto.
+             * @constructor
+             * @param {google.protobuf.IEnumValueDescriptorProto=} [properties] Properties to set
+             */
+            function EnumValueDescriptorProto(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * EnumValueDescriptorProto name.
+             * @member {string}name
+             * @memberof google.protobuf.EnumValueDescriptorProto
+             * @instance
+             */
+            EnumValueDescriptorProto.prototype.name = "";
+
+            /**
+             * EnumValueDescriptorProto number.
+             * @member {number}number
+             * @memberof google.protobuf.EnumValueDescriptorProto
+             * @instance
+             */
+            EnumValueDescriptorProto.prototype.number = 0;
+
+            /**
+             * EnumValueDescriptorProto options.
+             * @member {(google.protobuf.IEnumValueOptions|null|undefined)}options
+             * @memberof google.protobuf.EnumValueDescriptorProto
+             * @instance
+             */
+            EnumValueDescriptorProto.prototype.options = null;
+
+            /**
+             * Creates a new EnumValueDescriptorProto instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.EnumValueDescriptorProto
+             * @static
+             * @param {google.protobuf.IEnumValueDescriptorProto=} [properties] Properties to set
+             * @returns {google.protobuf.EnumValueDescriptorProto} EnumValueDescriptorProto instance
+             */
+            EnumValueDescriptorProto.create = function create(properties) {
+                return new EnumValueDescriptorProto(properties);
+            };
+
+            /**
+             * Encodes the specified EnumValueDescriptorProto message. Does not implicitly {@link google.protobuf.EnumValueDescriptorProto.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.EnumValueDescriptorProto
+             * @static
+             * @param {google.protobuf.IEnumValueDescriptorProto} message EnumValueDescriptorProto message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            EnumValueDescriptorProto.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.name != null && message.hasOwnProperty("name"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
+                if (message.number != null && message.hasOwnProperty("number"))
+                    writer.uint32(/* id 2, wireType 0 =*/16).int32(message.number);
+                if (message.options != null && message.hasOwnProperty("options"))
+                    $root.google.protobuf.EnumValueOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified EnumValueDescriptorProto message, length delimited. Does not implicitly {@link google.protobuf.EnumValueDescriptorProto.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.EnumValueDescriptorProto
+             * @static
+             * @param {google.protobuf.IEnumValueDescriptorProto} message EnumValueDescriptorProto message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            EnumValueDescriptorProto.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes an EnumValueDescriptorProto message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.EnumValueDescriptorProto
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.EnumValueDescriptorProto} EnumValueDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            EnumValueDescriptorProto.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.EnumValueDescriptorProto();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.name = reader.string();
+                        break;
+                    case 2:
+                        message.number = reader.int32();
+                        break;
+                    case 3:
+                        message.options = $root.google.protobuf.EnumValueOptions.decode(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes an EnumValueDescriptorProto message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.EnumValueDescriptorProto
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.EnumValueDescriptorProto} EnumValueDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            EnumValueDescriptorProto.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies an EnumValueDescriptorProto message.
+             * @function verify
+             * @memberof google.protobuf.EnumValueDescriptorProto
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            EnumValueDescriptorProto.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.name != null && message.hasOwnProperty("name"))
+                    if (!$util.isString(message.name))
+                        return "name: string expected";
+                if (message.number != null && message.hasOwnProperty("number"))
+                    if (!$util.isInteger(message.number))
+                        return "number: integer expected";
+                if (message.options != null && message.hasOwnProperty("options")) {
+                    var error = $root.google.protobuf.EnumValueOptions.verify(message.options);
+                    if (error)
+                        return "options." + error;
+                }
+                return null;
+            };
+
+            /**
+             * Creates an EnumValueDescriptorProto message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.EnumValueDescriptorProto
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.EnumValueDescriptorProto} EnumValueDescriptorProto
+             */
+            EnumValueDescriptorProto.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.EnumValueDescriptorProto)
+                    return object;
+                var message = new $root.google.protobuf.EnumValueDescriptorProto();
+                if (object.name != null)
+                    message.name = String(object.name);
+                if (object.number != null)
+                    message.number = object.number | 0;
+                if (object.options != null) {
+                    if (typeof object.options !== "object")
+                        throw TypeError(".google.protobuf.EnumValueDescriptorProto.options: object expected");
+                    message.options = $root.google.protobuf.EnumValueOptions.fromObject(object.options);
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from an EnumValueDescriptorProto message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.EnumValueDescriptorProto
+             * @static
+             * @param {google.protobuf.EnumValueDescriptorProto} message EnumValueDescriptorProto
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            EnumValueDescriptorProto.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.name = "";
+                    object.number = 0;
+                    object.options = null;
+                }
+                if (message.name != null && message.hasOwnProperty("name"))
+                    object.name = message.name;
+                if (message.number != null && message.hasOwnProperty("number"))
+                    object.number = message.number;
+                if (message.options != null && message.hasOwnProperty("options"))
+                    object.options = $root.google.protobuf.EnumValueOptions.toObject(message.options, options);
+                return object;
+            };
+
+            /**
+             * Converts this EnumValueDescriptorProto to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.EnumValueDescriptorProto
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            EnumValueDescriptorProto.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return EnumValueDescriptorProto;
+        })();
+
+        protobuf.ServiceDescriptorProto = (function() {
+
+            /**
+             * Properties of a ServiceDescriptorProto.
+             * @memberof google.protobuf
+             * @interface IServiceDescriptorProto
+             * @property {string} [name] ServiceDescriptorProto name
+             * @property {Array.<google.protobuf.IMethodDescriptorProto>} [method] ServiceDescriptorProto method
+             * @property {google.protobuf.IServiceOptions} [options] ServiceDescriptorProto options
+             */
+
+            /**
+             * Constructs a new ServiceDescriptorProto.
+             * @memberof google.protobuf
+             * @classdesc Represents a ServiceDescriptorProto.
+             * @constructor
+             * @param {google.protobuf.IServiceDescriptorProto=} [properties] Properties to set
+             */
+            function ServiceDescriptorProto(properties) {
+                this.method = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * ServiceDescriptorProto name.
+             * @member {string}name
+             * @memberof google.protobuf.ServiceDescriptorProto
+             * @instance
+             */
+            ServiceDescriptorProto.prototype.name = "";
+
+            /**
+             * ServiceDescriptorProto method.
+             * @member {Array.<google.protobuf.IMethodDescriptorProto>}method
+             * @memberof google.protobuf.ServiceDescriptorProto
+             * @instance
+             */
+            ServiceDescriptorProto.prototype.method = $util.emptyArray;
+
+            /**
+             * ServiceDescriptorProto options.
+             * @member {(google.protobuf.IServiceOptions|null|undefined)}options
+             * @memberof google.protobuf.ServiceDescriptorProto
+             * @instance
+             */
+            ServiceDescriptorProto.prototype.options = null;
+
+            /**
+             * Creates a new ServiceDescriptorProto instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.ServiceDescriptorProto
+             * @static
+             * @param {google.protobuf.IServiceDescriptorProto=} [properties] Properties to set
+             * @returns {google.protobuf.ServiceDescriptorProto} ServiceDescriptorProto instance
+             */
+            ServiceDescriptorProto.create = function create(properties) {
+                return new ServiceDescriptorProto(properties);
+            };
+
+            /**
+             * Encodes the specified ServiceDescriptorProto message. Does not implicitly {@link google.protobuf.ServiceDescriptorProto.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.ServiceDescriptorProto
+             * @static
+             * @param {google.protobuf.IServiceDescriptorProto} message ServiceDescriptorProto message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            ServiceDescriptorProto.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.name != null && message.hasOwnProperty("name"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
+                if (message.method != null && message.method.length)
+                    for (var i = 0; i < message.method.length; ++i)
+                        $root.google.protobuf.MethodDescriptorProto.encode(message.method[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                if (message.options != null && message.hasOwnProperty("options"))
+                    $root.google.protobuf.ServiceOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified ServiceDescriptorProto message, length delimited. Does not implicitly {@link google.protobuf.ServiceDescriptorProto.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.ServiceDescriptorProto
+             * @static
+             * @param {google.protobuf.IServiceDescriptorProto} message ServiceDescriptorProto message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            ServiceDescriptorProto.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a ServiceDescriptorProto message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.ServiceDescriptorProto
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.ServiceDescriptorProto} ServiceDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            ServiceDescriptorProto.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.ServiceDescriptorProto();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.name = reader.string();
+                        break;
+                    case 2:
+                        if (!(message.method && message.method.length))
+                            message.method = [];
+                        message.method.push($root.google.protobuf.MethodDescriptorProto.decode(reader, reader.uint32()));
+                        break;
+                    case 3:
+                        message.options = $root.google.protobuf.ServiceOptions.decode(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a ServiceDescriptorProto message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.ServiceDescriptorProto
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.ServiceDescriptorProto} ServiceDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            ServiceDescriptorProto.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a ServiceDescriptorProto message.
+             * @function verify
+             * @memberof google.protobuf.ServiceDescriptorProto
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            ServiceDescriptorProto.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.name != null && message.hasOwnProperty("name"))
+                    if (!$util.isString(message.name))
+                        return "name: string expected";
+                if (message.method != null && message.hasOwnProperty("method")) {
+                    if (!Array.isArray(message.method))
+                        return "method: array expected";
+                    for (var i = 0; i < message.method.length; ++i) {
+                        var error = $root.google.protobuf.MethodDescriptorProto.verify(message.method[i]);
+                        if (error)
+                            return "method." + error;
+                    }
+                }
+                if (message.options != null && message.hasOwnProperty("options")) {
+                    error = $root.google.protobuf.ServiceOptions.verify(message.options);
+                    if (error)
+                        return "options." + error;
+                }
+                return null;
+            };
+
+            /**
+             * Creates a ServiceDescriptorProto message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.ServiceDescriptorProto
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.ServiceDescriptorProto} ServiceDescriptorProto
+             */
+            ServiceDescriptorProto.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.ServiceDescriptorProto)
+                    return object;
+                var message = new $root.google.protobuf.ServiceDescriptorProto();
+                if (object.name != null)
+                    message.name = String(object.name);
+                if (object.method) {
+                    if (!Array.isArray(object.method))
+                        throw TypeError(".google.protobuf.ServiceDescriptorProto.method: array expected");
+                    message.method = [];
+                    for (var i = 0; i < object.method.length; ++i) {
+                        if (typeof object.method[i] !== "object")
+                            throw TypeError(".google.protobuf.ServiceDescriptorProto.method: object expected");
+                        message.method[i] = $root.google.protobuf.MethodDescriptorProto.fromObject(object.method[i]);
+                    }
+                }
+                if (object.options != null) {
+                    if (typeof object.options !== "object")
+                        throw TypeError(".google.protobuf.ServiceDescriptorProto.options: object expected");
+                    message.options = $root.google.protobuf.ServiceOptions.fromObject(object.options);
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a ServiceDescriptorProto message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.ServiceDescriptorProto
+             * @static
+             * @param {google.protobuf.ServiceDescriptorProto} message ServiceDescriptorProto
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            ServiceDescriptorProto.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.method = [];
+                if (options.defaults) {
+                    object.name = "";
+                    object.options = null;
+                }
+                if (message.name != null && message.hasOwnProperty("name"))
+                    object.name = message.name;
+                if (message.method && message.method.length) {
+                    object.method = [];
+                    for (var j = 0; j < message.method.length; ++j)
+                        object.method[j] = $root.google.protobuf.MethodDescriptorProto.toObject(message.method[j], options);
+                }
+                if (message.options != null && message.hasOwnProperty("options"))
+                    object.options = $root.google.protobuf.ServiceOptions.toObject(message.options, options);
+                return object;
+            };
+
+            /**
+             * Converts this ServiceDescriptorProto to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.ServiceDescriptorProto
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            ServiceDescriptorProto.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return ServiceDescriptorProto;
+        })();
+
+        protobuf.MethodDescriptorProto = (function() {
+
+            /**
+             * Properties of a MethodDescriptorProto.
+             * @memberof google.protobuf
+             * @interface IMethodDescriptorProto
+             * @property {string} [name] MethodDescriptorProto name
+             * @property {string} [inputType] MethodDescriptorProto inputType
+             * @property {string} [outputType] MethodDescriptorProto outputType
+             * @property {google.protobuf.IMethodOptions} [options] MethodDescriptorProto options
+             * @property {boolean} [clientStreaming] MethodDescriptorProto clientStreaming
+             * @property {boolean} [serverStreaming] MethodDescriptorProto serverStreaming
+             */
+
+            /**
+             * Constructs a new MethodDescriptorProto.
+             * @memberof google.protobuf
+             * @classdesc Represents a MethodDescriptorProto.
+             * @constructor
+             * @param {google.protobuf.IMethodDescriptorProto=} [properties] Properties to set
+             */
+            function MethodDescriptorProto(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * MethodDescriptorProto name.
+             * @member {string}name
+             * @memberof google.protobuf.MethodDescriptorProto
+             * @instance
+             */
+            MethodDescriptorProto.prototype.name = "";
+
+            /**
+             * MethodDescriptorProto inputType.
+             * @member {string}inputType
+             * @memberof google.protobuf.MethodDescriptorProto
+             * @instance
+             */
+            MethodDescriptorProto.prototype.inputType = "";
+
+            /**
+             * MethodDescriptorProto outputType.
+             * @member {string}outputType
+             * @memberof google.protobuf.MethodDescriptorProto
+             * @instance
+             */
+            MethodDescriptorProto.prototype.outputType = "";
+
+            /**
+             * MethodDescriptorProto options.
+             * @member {(google.protobuf.IMethodOptions|null|undefined)}options
+             * @memberof google.protobuf.MethodDescriptorProto
+             * @instance
+             */
+            MethodDescriptorProto.prototype.options = null;
+
+            /**
+             * MethodDescriptorProto clientStreaming.
+             * @member {boolean}clientStreaming
+             * @memberof google.protobuf.MethodDescriptorProto
+             * @instance
+             */
+            MethodDescriptorProto.prototype.clientStreaming = false;
+
+            /**
+             * MethodDescriptorProto serverStreaming.
+             * @member {boolean}serverStreaming
+             * @memberof google.protobuf.MethodDescriptorProto
+             * @instance
+             */
+            MethodDescriptorProto.prototype.serverStreaming = false;
+
+            /**
+             * Creates a new MethodDescriptorProto instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.MethodDescriptorProto
+             * @static
+             * @param {google.protobuf.IMethodDescriptorProto=} [properties] Properties to set
+             * @returns {google.protobuf.MethodDescriptorProto} MethodDescriptorProto instance
+             */
+            MethodDescriptorProto.create = function create(properties) {
+                return new MethodDescriptorProto(properties);
+            };
+
+            /**
+             * Encodes the specified MethodDescriptorProto message. Does not implicitly {@link google.protobuf.MethodDescriptorProto.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.MethodDescriptorProto
+             * @static
+             * @param {google.protobuf.IMethodDescriptorProto} message MethodDescriptorProto message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            MethodDescriptorProto.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.name != null && message.hasOwnProperty("name"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
+                if (message.inputType != null && message.hasOwnProperty("inputType"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.inputType);
+                if (message.outputType != null && message.hasOwnProperty("outputType"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.outputType);
+                if (message.options != null && message.hasOwnProperty("options"))
+                    $root.google.protobuf.MethodOptions.encode(message.options, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                if (message.clientStreaming != null && message.hasOwnProperty("clientStreaming"))
+                    writer.uint32(/* id 5, wireType 0 =*/40).bool(message.clientStreaming);
+                if (message.serverStreaming != null && message.hasOwnProperty("serverStreaming"))
+                    writer.uint32(/* id 6, wireType 0 =*/48).bool(message.serverStreaming);
+                return writer;
+            };
+
+            /**
+             * Encodes the specified MethodDescriptorProto message, length delimited. Does not implicitly {@link google.protobuf.MethodDescriptorProto.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.MethodDescriptorProto
+             * @static
+             * @param {google.protobuf.IMethodDescriptorProto} message MethodDescriptorProto message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            MethodDescriptorProto.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a MethodDescriptorProto message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.MethodDescriptorProto
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.MethodDescriptorProto} MethodDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            MethodDescriptorProto.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.MethodDescriptorProto();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.name = reader.string();
+                        break;
+                    case 2:
+                        message.inputType = reader.string();
+                        break;
+                    case 3:
+                        message.outputType = reader.string();
+                        break;
+                    case 4:
+                        message.options = $root.google.protobuf.MethodOptions.decode(reader, reader.uint32());
+                        break;
+                    case 5:
+                        message.clientStreaming = reader.bool();
+                        break;
+                    case 6:
+                        message.serverStreaming = reader.bool();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a MethodDescriptorProto message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.MethodDescriptorProto
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.MethodDescriptorProto} MethodDescriptorProto
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            MethodDescriptorProto.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a MethodDescriptorProto message.
+             * @function verify
+             * @memberof google.protobuf.MethodDescriptorProto
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            MethodDescriptorProto.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.name != null && message.hasOwnProperty("name"))
+                    if (!$util.isString(message.name))
+                        return "name: string expected";
+                if (message.inputType != null && message.hasOwnProperty("inputType"))
+                    if (!$util.isString(message.inputType))
+                        return "inputType: string expected";
+                if (message.outputType != null && message.hasOwnProperty("outputType"))
+                    if (!$util.isString(message.outputType))
+                        return "outputType: string expected";
+                if (message.options != null && message.hasOwnProperty("options")) {
+                    var error = $root.google.protobuf.MethodOptions.verify(message.options);
+                    if (error)
+                        return "options." + error;
+                }
+                if (message.clientStreaming != null && message.hasOwnProperty("clientStreaming"))
+                    if (typeof message.clientStreaming !== "boolean")
+                        return "clientStreaming: boolean expected";
+                if (message.serverStreaming != null && message.hasOwnProperty("serverStreaming"))
+                    if (typeof message.serverStreaming !== "boolean")
+                        return "serverStreaming: boolean expected";
+                return null;
+            };
+
+            /**
+             * Creates a MethodDescriptorProto message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.MethodDescriptorProto
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.MethodDescriptorProto} MethodDescriptorProto
+             */
+            MethodDescriptorProto.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.MethodDescriptorProto)
+                    return object;
+                var message = new $root.google.protobuf.MethodDescriptorProto();
+                if (object.name != null)
+                    message.name = String(object.name);
+                if (object.inputType != null)
+                    message.inputType = String(object.inputType);
+                if (object.outputType != null)
+                    message.outputType = String(object.outputType);
+                if (object.options != null) {
+                    if (typeof object.options !== "object")
+                        throw TypeError(".google.protobuf.MethodDescriptorProto.options: object expected");
+                    message.options = $root.google.protobuf.MethodOptions.fromObject(object.options);
+                }
+                if (object.clientStreaming != null)
+                    message.clientStreaming = Boolean(object.clientStreaming);
+                if (object.serverStreaming != null)
+                    message.serverStreaming = Boolean(object.serverStreaming);
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a MethodDescriptorProto message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.MethodDescriptorProto
+             * @static
+             * @param {google.protobuf.MethodDescriptorProto} message MethodDescriptorProto
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            MethodDescriptorProto.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.name = "";
+                    object.inputType = "";
+                    object.outputType = "";
+                    object.options = null;
+                    object.clientStreaming = false;
+                    object.serverStreaming = false;
+                }
+                if (message.name != null && message.hasOwnProperty("name"))
+                    object.name = message.name;
+                if (message.inputType != null && message.hasOwnProperty("inputType"))
+                    object.inputType = message.inputType;
+                if (message.outputType != null && message.hasOwnProperty("outputType"))
+                    object.outputType = message.outputType;
+                if (message.options != null && message.hasOwnProperty("options"))
+                    object.options = $root.google.protobuf.MethodOptions.toObject(message.options, options);
+                if (message.clientStreaming != null && message.hasOwnProperty("clientStreaming"))
+                    object.clientStreaming = message.clientStreaming;
+                if (message.serverStreaming != null && message.hasOwnProperty("serverStreaming"))
+                    object.serverStreaming = message.serverStreaming;
+                return object;
+            };
+
+            /**
+             * Converts this MethodDescriptorProto to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.MethodDescriptorProto
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            MethodDescriptorProto.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return MethodDescriptorProto;
+        })();
+
+        protobuf.FileOptions = (function() {
+
+            /**
+             * Properties of a FileOptions.
+             * @memberof google.protobuf
+             * @interface IFileOptions
+             * @property {string} [javaPackage] FileOptions javaPackage
+             * @property {string} [javaOuterClassname] FileOptions javaOuterClassname
+             * @property {boolean} [javaMultipleFiles] FileOptions javaMultipleFiles
+             * @property {boolean} [javaGenerateEqualsAndHash] FileOptions javaGenerateEqualsAndHash
+             * @property {boolean} [javaStringCheckUtf8] FileOptions javaStringCheckUtf8
+             * @property {google.protobuf.FileOptions.OptimizeMode} [optimizeFor] FileOptions optimizeFor
+             * @property {string} [goPackage] FileOptions goPackage
+             * @property {boolean} [ccGenericServices] FileOptions ccGenericServices
+             * @property {boolean} [javaGenericServices] FileOptions javaGenericServices
+             * @property {boolean} [pyGenericServices] FileOptions pyGenericServices
+             * @property {boolean} [deprecated] FileOptions deprecated
+             * @property {boolean} [ccEnableArenas] FileOptions ccEnableArenas
+             * @property {string} [objcClassPrefix] FileOptions objcClassPrefix
+             * @property {string} [csharpNamespace] FileOptions csharpNamespace
+             * @property {Array.<google.protobuf.IUninterpretedOption>} [uninterpretedOption] FileOptions uninterpretedOption
+             */
+
+            /**
+             * Constructs a new FileOptions.
+             * @memberof google.protobuf
+             * @classdesc Represents a FileOptions.
+             * @constructor
+             * @param {google.protobuf.IFileOptions=} [properties] Properties to set
+             */
+            function FileOptions(properties) {
+                this.uninterpretedOption = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * FileOptions javaPackage.
+             * @member {string}javaPackage
+             * @memberof google.protobuf.FileOptions
+             * @instance
+             */
+            FileOptions.prototype.javaPackage = "";
+
+            /**
+             * FileOptions javaOuterClassname.
+             * @member {string}javaOuterClassname
+             * @memberof google.protobuf.FileOptions
+             * @instance
+             */
+            FileOptions.prototype.javaOuterClassname = "";
+
+            /**
+             * FileOptions javaMultipleFiles.
+             * @member {boolean}javaMultipleFiles
+             * @memberof google.protobuf.FileOptions
+             * @instance
+             */
+            FileOptions.prototype.javaMultipleFiles = false;
+
+            /**
+             * FileOptions javaGenerateEqualsAndHash.
+             * @member {boolean}javaGenerateEqualsAndHash
+             * @memberof google.protobuf.FileOptions
+             * @instance
+             */
+            FileOptions.prototype.javaGenerateEqualsAndHash = false;
+
+            /**
+             * FileOptions javaStringCheckUtf8.
+             * @member {boolean}javaStringCheckUtf8
+             * @memberof google.protobuf.FileOptions
+             * @instance
+             */
+            FileOptions.prototype.javaStringCheckUtf8 = false;
+
+            /**
+             * FileOptions optimizeFor.
+             * @member {google.protobuf.FileOptions.OptimizeMode}optimizeFor
+             * @memberof google.protobuf.FileOptions
+             * @instance
+             */
+            FileOptions.prototype.optimizeFor = 1;
+
+            /**
+             * FileOptions goPackage.
+             * @member {string}goPackage
+             * @memberof google.protobuf.FileOptions
+             * @instance
+             */
+            FileOptions.prototype.goPackage = "";
+
+            /**
+             * FileOptions ccGenericServices.
+             * @member {boolean}ccGenericServices
+             * @memberof google.protobuf.FileOptions
+             * @instance
+             */
+            FileOptions.prototype.ccGenericServices = false;
+
+            /**
+             * FileOptions javaGenericServices.
+             * @member {boolean}javaGenericServices
+             * @memberof google.protobuf.FileOptions
+             * @instance
+             */
+            FileOptions.prototype.javaGenericServices = false;
+
+            /**
+             * FileOptions pyGenericServices.
+             * @member {boolean}pyGenericServices
+             * @memberof google.protobuf.FileOptions
+             * @instance
+             */
+            FileOptions.prototype.pyGenericServices = false;
+
+            /**
+             * FileOptions deprecated.
+             * @member {boolean}deprecated
+             * @memberof google.protobuf.FileOptions
+             * @instance
+             */
+            FileOptions.prototype.deprecated = false;
+
+            /**
+             * FileOptions ccEnableArenas.
+             * @member {boolean}ccEnableArenas
+             * @memberof google.protobuf.FileOptions
+             * @instance
+             */
+            FileOptions.prototype.ccEnableArenas = false;
+
+            /**
+             * FileOptions objcClassPrefix.
+             * @member {string}objcClassPrefix
+             * @memberof google.protobuf.FileOptions
+             * @instance
+             */
+            FileOptions.prototype.objcClassPrefix = "";
+
+            /**
+             * FileOptions csharpNamespace.
+             * @member {string}csharpNamespace
+             * @memberof google.protobuf.FileOptions
+             * @instance
+             */
+            FileOptions.prototype.csharpNamespace = "";
+
+            /**
+             * FileOptions uninterpretedOption.
+             * @member {Array.<google.protobuf.IUninterpretedOption>}uninterpretedOption
+             * @memberof google.protobuf.FileOptions
+             * @instance
+             */
+            FileOptions.prototype.uninterpretedOption = $util.emptyArray;
+
+            /**
+             * Creates a new FileOptions instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.FileOptions
+             * @static
+             * @param {google.protobuf.IFileOptions=} [properties] Properties to set
+             * @returns {google.protobuf.FileOptions} FileOptions instance
+             */
+            FileOptions.create = function create(properties) {
+                return new FileOptions(properties);
+            };
+
+            /**
+             * Encodes the specified FileOptions message. Does not implicitly {@link google.protobuf.FileOptions.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.FileOptions
+             * @static
+             * @param {google.protobuf.IFileOptions} message FileOptions message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            FileOptions.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.javaPackage != null && message.hasOwnProperty("javaPackage"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.javaPackage);
+                if (message.javaOuterClassname != null && message.hasOwnProperty("javaOuterClassname"))
+                    writer.uint32(/* id 8, wireType 2 =*/66).string(message.javaOuterClassname);
+                if (message.optimizeFor != null && message.hasOwnProperty("optimizeFor"))
+                    writer.uint32(/* id 9, wireType 0 =*/72).int32(message.optimizeFor);
+                if (message.javaMultipleFiles != null && message.hasOwnProperty("javaMultipleFiles"))
+                    writer.uint32(/* id 10, wireType 0 =*/80).bool(message.javaMultipleFiles);
+                if (message.goPackage != null && message.hasOwnProperty("goPackage"))
+                    writer.uint32(/* id 11, wireType 2 =*/90).string(message.goPackage);
+                if (message.ccGenericServices != null && message.hasOwnProperty("ccGenericServices"))
+                    writer.uint32(/* id 16, wireType 0 =*/128).bool(message.ccGenericServices);
+                if (message.javaGenericServices != null && message.hasOwnProperty("javaGenericServices"))
+                    writer.uint32(/* id 17, wireType 0 =*/136).bool(message.javaGenericServices);
+                if (message.pyGenericServices != null && message.hasOwnProperty("pyGenericServices"))
+                    writer.uint32(/* id 18, wireType 0 =*/144).bool(message.pyGenericServices);
+                if (message.javaGenerateEqualsAndHash != null && message.hasOwnProperty("javaGenerateEqualsAndHash"))
+                    writer.uint32(/* id 20, wireType 0 =*/160).bool(message.javaGenerateEqualsAndHash);
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    writer.uint32(/* id 23, wireType 0 =*/184).bool(message.deprecated);
+                if (message.javaStringCheckUtf8 != null && message.hasOwnProperty("javaStringCheckUtf8"))
+                    writer.uint32(/* id 27, wireType 0 =*/216).bool(message.javaStringCheckUtf8);
+                if (message.ccEnableArenas != null && message.hasOwnProperty("ccEnableArenas"))
+                    writer.uint32(/* id 31, wireType 0 =*/248).bool(message.ccEnableArenas);
+                if (message.objcClassPrefix != null && message.hasOwnProperty("objcClassPrefix"))
+                    writer.uint32(/* id 36, wireType 2 =*/290).string(message.objcClassPrefix);
+                if (message.csharpNamespace != null && message.hasOwnProperty("csharpNamespace"))
+                    writer.uint32(/* id 37, wireType 2 =*/298).string(message.csharpNamespace);
+                if (message.uninterpretedOption != null && message.uninterpretedOption.length)
+                    for (var i = 0; i < message.uninterpretedOption.length; ++i)
+                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified FileOptions message, length delimited. Does not implicitly {@link google.protobuf.FileOptions.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.FileOptions
+             * @static
+             * @param {google.protobuf.IFileOptions} message FileOptions message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            FileOptions.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a FileOptions message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.FileOptions
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.FileOptions} FileOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            FileOptions.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.FileOptions();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.javaPackage = reader.string();
+                        break;
+                    case 8:
+                        message.javaOuterClassname = reader.string();
+                        break;
+                    case 10:
+                        message.javaMultipleFiles = reader.bool();
+                        break;
+                    case 20:
+                        message.javaGenerateEqualsAndHash = reader.bool();
+                        break;
+                    case 27:
+                        message.javaStringCheckUtf8 = reader.bool();
+                        break;
+                    case 9:
+                        message.optimizeFor = reader.int32();
+                        break;
+                    case 11:
+                        message.goPackage = reader.string();
+                        break;
+                    case 16:
+                        message.ccGenericServices = reader.bool();
+                        break;
+                    case 17:
+                        message.javaGenericServices = reader.bool();
+                        break;
+                    case 18:
+                        message.pyGenericServices = reader.bool();
+                        break;
+                    case 23:
+                        message.deprecated = reader.bool();
+                        break;
+                    case 31:
+                        message.ccEnableArenas = reader.bool();
+                        break;
+                    case 36:
+                        message.objcClassPrefix = reader.string();
+                        break;
+                    case 37:
+                        message.csharpNamespace = reader.string();
+                        break;
+                    case 999:
+                        if (!(message.uninterpretedOption && message.uninterpretedOption.length))
+                            message.uninterpretedOption = [];
+                        message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a FileOptions message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.FileOptions
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.FileOptions} FileOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            FileOptions.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a FileOptions message.
+             * @function verify
+             * @memberof google.protobuf.FileOptions
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            FileOptions.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.javaPackage != null && message.hasOwnProperty("javaPackage"))
+                    if (!$util.isString(message.javaPackage))
+                        return "javaPackage: string expected";
+                if (message.javaOuterClassname != null && message.hasOwnProperty("javaOuterClassname"))
+                    if (!$util.isString(message.javaOuterClassname))
+                        return "javaOuterClassname: string expected";
+                if (message.javaMultipleFiles != null && message.hasOwnProperty("javaMultipleFiles"))
+                    if (typeof message.javaMultipleFiles !== "boolean")
+                        return "javaMultipleFiles: boolean expected";
+                if (message.javaGenerateEqualsAndHash != null && message.hasOwnProperty("javaGenerateEqualsAndHash"))
+                    if (typeof message.javaGenerateEqualsAndHash !== "boolean")
+                        return "javaGenerateEqualsAndHash: boolean expected";
+                if (message.javaStringCheckUtf8 != null && message.hasOwnProperty("javaStringCheckUtf8"))
+                    if (typeof message.javaStringCheckUtf8 !== "boolean")
+                        return "javaStringCheckUtf8: boolean expected";
+                if (message.optimizeFor != null && message.hasOwnProperty("optimizeFor"))
+                    switch (message.optimizeFor) {
+                    default:
+                        return "optimizeFor: enum value expected";
+                    case 1:
+                    case 2:
+                    case 3:
+                        break;
+                    }
+                if (message.goPackage != null && message.hasOwnProperty("goPackage"))
+                    if (!$util.isString(message.goPackage))
+                        return "goPackage: string expected";
+                if (message.ccGenericServices != null && message.hasOwnProperty("ccGenericServices"))
+                    if (typeof message.ccGenericServices !== "boolean")
+                        return "ccGenericServices: boolean expected";
+                if (message.javaGenericServices != null && message.hasOwnProperty("javaGenericServices"))
+                    if (typeof message.javaGenericServices !== "boolean")
+                        return "javaGenericServices: boolean expected";
+                if (message.pyGenericServices != null && message.hasOwnProperty("pyGenericServices"))
+                    if (typeof message.pyGenericServices !== "boolean")
+                        return "pyGenericServices: boolean expected";
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    if (typeof message.deprecated !== "boolean")
+                        return "deprecated: boolean expected";
+                if (message.ccEnableArenas != null && message.hasOwnProperty("ccEnableArenas"))
+                    if (typeof message.ccEnableArenas !== "boolean")
+                        return "ccEnableArenas: boolean expected";
+                if (message.objcClassPrefix != null && message.hasOwnProperty("objcClassPrefix"))
+                    if (!$util.isString(message.objcClassPrefix))
+                        return "objcClassPrefix: string expected";
+                if (message.csharpNamespace != null && message.hasOwnProperty("csharpNamespace"))
+                    if (!$util.isString(message.csharpNamespace))
+                        return "csharpNamespace: string expected";
+                if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
+                    if (!Array.isArray(message.uninterpretedOption))
+                        return "uninterpretedOption: array expected";
+                    for (var i = 0; i < message.uninterpretedOption.length; ++i) {
+                        var error = $root.google.protobuf.UninterpretedOption.verify(message.uninterpretedOption[i]);
+                        if (error)
+                            return "uninterpretedOption." + error;
+                    }
+                }
+                return null;
+            };
+
+            /**
+             * Creates a FileOptions message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.FileOptions
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.FileOptions} FileOptions
+             */
+            FileOptions.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.FileOptions)
+                    return object;
+                var message = new $root.google.protobuf.FileOptions();
+                if (object.javaPackage != null)
+                    message.javaPackage = String(object.javaPackage);
+                if (object.javaOuterClassname != null)
+                    message.javaOuterClassname = String(object.javaOuterClassname);
+                if (object.javaMultipleFiles != null)
+                    message.javaMultipleFiles = Boolean(object.javaMultipleFiles);
+                if (object.javaGenerateEqualsAndHash != null)
+                    message.javaGenerateEqualsAndHash = Boolean(object.javaGenerateEqualsAndHash);
+                if (object.javaStringCheckUtf8 != null)
+                    message.javaStringCheckUtf8 = Boolean(object.javaStringCheckUtf8);
+                switch (object.optimizeFor) {
+                case "SPEED":
+                case 1:
+                    message.optimizeFor = 1;
+                    break;
+                case "CODE_SIZE":
+                case 2:
+                    message.optimizeFor = 2;
+                    break;
+                case "LITE_RUNTIME":
+                case 3:
+                    message.optimizeFor = 3;
+                    break;
+                }
+                if (object.goPackage != null)
+                    message.goPackage = String(object.goPackage);
+                if (object.ccGenericServices != null)
+                    message.ccGenericServices = Boolean(object.ccGenericServices);
+                if (object.javaGenericServices != null)
+                    message.javaGenericServices = Boolean(object.javaGenericServices);
+                if (object.pyGenericServices != null)
+                    message.pyGenericServices = Boolean(object.pyGenericServices);
+                if (object.deprecated != null)
+                    message.deprecated = Boolean(object.deprecated);
+                if (object.ccEnableArenas != null)
+                    message.ccEnableArenas = Boolean(object.ccEnableArenas);
+                if (object.objcClassPrefix != null)
+                    message.objcClassPrefix = String(object.objcClassPrefix);
+                if (object.csharpNamespace != null)
+                    message.csharpNamespace = String(object.csharpNamespace);
+                if (object.uninterpretedOption) {
+                    if (!Array.isArray(object.uninterpretedOption))
+                        throw TypeError(".google.protobuf.FileOptions.uninterpretedOption: array expected");
+                    message.uninterpretedOption = [];
+                    for (var i = 0; i < object.uninterpretedOption.length; ++i) {
+                        if (typeof object.uninterpretedOption[i] !== "object")
+                            throw TypeError(".google.protobuf.FileOptions.uninterpretedOption: object expected");
+                        message.uninterpretedOption[i] = $root.google.protobuf.UninterpretedOption.fromObject(object.uninterpretedOption[i]);
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a FileOptions message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.FileOptions
+             * @static
+             * @param {google.protobuf.FileOptions} message FileOptions
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            FileOptions.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.uninterpretedOption = [];
+                if (options.defaults) {
+                    object.javaPackage = "";
+                    object.javaOuterClassname = "";
+                    object.optimizeFor = options.enums === String ? "SPEED" : 1;
+                    object.javaMultipleFiles = false;
+                    object.goPackage = "";
+                    object.ccGenericServices = false;
+                    object.javaGenericServices = false;
+                    object.pyGenericServices = false;
+                    object.javaGenerateEqualsAndHash = false;
+                    object.deprecated = false;
+                    object.javaStringCheckUtf8 = false;
+                    object.ccEnableArenas = false;
+                    object.objcClassPrefix = "";
+                    object.csharpNamespace = "";
+                }
+                if (message.javaPackage != null && message.hasOwnProperty("javaPackage"))
+                    object.javaPackage = message.javaPackage;
+                if (message.javaOuterClassname != null && message.hasOwnProperty("javaOuterClassname"))
+                    object.javaOuterClassname = message.javaOuterClassname;
+                if (message.optimizeFor != null && message.hasOwnProperty("optimizeFor"))
+                    object.optimizeFor = options.enums === String ? $root.google.protobuf.FileOptions.OptimizeMode[message.optimizeFor] : message.optimizeFor;
+                if (message.javaMultipleFiles != null && message.hasOwnProperty("javaMultipleFiles"))
+                    object.javaMultipleFiles = message.javaMultipleFiles;
+                if (message.goPackage != null && message.hasOwnProperty("goPackage"))
+                    object.goPackage = message.goPackage;
+                if (message.ccGenericServices != null && message.hasOwnProperty("ccGenericServices"))
+                    object.ccGenericServices = message.ccGenericServices;
+                if (message.javaGenericServices != null && message.hasOwnProperty("javaGenericServices"))
+                    object.javaGenericServices = message.javaGenericServices;
+                if (message.pyGenericServices != null && message.hasOwnProperty("pyGenericServices"))
+                    object.pyGenericServices = message.pyGenericServices;
+                if (message.javaGenerateEqualsAndHash != null && message.hasOwnProperty("javaGenerateEqualsAndHash"))
+                    object.javaGenerateEqualsAndHash = message.javaGenerateEqualsAndHash;
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    object.deprecated = message.deprecated;
+                if (message.javaStringCheckUtf8 != null && message.hasOwnProperty("javaStringCheckUtf8"))
+                    object.javaStringCheckUtf8 = message.javaStringCheckUtf8;
+                if (message.ccEnableArenas != null && message.hasOwnProperty("ccEnableArenas"))
+                    object.ccEnableArenas = message.ccEnableArenas;
+                if (message.objcClassPrefix != null && message.hasOwnProperty("objcClassPrefix"))
+                    object.objcClassPrefix = message.objcClassPrefix;
+                if (message.csharpNamespace != null && message.hasOwnProperty("csharpNamespace"))
+                    object.csharpNamespace = message.csharpNamespace;
+                if (message.uninterpretedOption && message.uninterpretedOption.length) {
+                    object.uninterpretedOption = [];
+                    for (var j = 0; j < message.uninterpretedOption.length; ++j)
+                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options);
+                }
+                return object;
+            };
+
+            /**
+             * Converts this FileOptions to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.FileOptions
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            FileOptions.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            /**
+             * OptimizeMode enum.
+             * @enum {string}
+             * @property {number} SPEED=1 SPEED value
+             * @property {number} CODE_SIZE=2 CODE_SIZE value
+             * @property {number} LITE_RUNTIME=3 LITE_RUNTIME value
+             */
+            FileOptions.OptimizeMode = (function() {
+                var valuesById = {}, values = Object.create(valuesById);
+                values[valuesById[1] = "SPEED"] = 1;
+                values[valuesById[2] = "CODE_SIZE"] = 2;
+                values[valuesById[3] = "LITE_RUNTIME"] = 3;
+                return values;
+            })();
+
+            return FileOptions;
+        })();
+
+        protobuf.MessageOptions = (function() {
+
+            /**
+             * Properties of a MessageOptions.
+             * @memberof google.protobuf
+             * @interface IMessageOptions
+             * @property {boolean} [messageSetWireFormat] MessageOptions messageSetWireFormat
+             * @property {boolean} [noStandardDescriptorAccessor] MessageOptions noStandardDescriptorAccessor
+             * @property {boolean} [deprecated] MessageOptions deprecated
+             * @property {boolean} [mapEntry] MessageOptions mapEntry
+             * @property {Array.<google.protobuf.IUninterpretedOption>} [uninterpretedOption] MessageOptions uninterpretedOption
+             */
+
+            /**
+             * Constructs a new MessageOptions.
+             * @memberof google.protobuf
+             * @classdesc Represents a MessageOptions.
+             * @constructor
+             * @param {google.protobuf.IMessageOptions=} [properties] Properties to set
+             */
+            function MessageOptions(properties) {
+                this.uninterpretedOption = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * MessageOptions messageSetWireFormat.
+             * @member {boolean}messageSetWireFormat
+             * @memberof google.protobuf.MessageOptions
+             * @instance
+             */
+            MessageOptions.prototype.messageSetWireFormat = false;
+
+            /**
+             * MessageOptions noStandardDescriptorAccessor.
+             * @member {boolean}noStandardDescriptorAccessor
+             * @memberof google.protobuf.MessageOptions
+             * @instance
+             */
+            MessageOptions.prototype.noStandardDescriptorAccessor = false;
+
+            /**
+             * MessageOptions deprecated.
+             * @member {boolean}deprecated
+             * @memberof google.protobuf.MessageOptions
+             * @instance
+             */
+            MessageOptions.prototype.deprecated = false;
+
+            /**
+             * MessageOptions mapEntry.
+             * @member {boolean}mapEntry
+             * @memberof google.protobuf.MessageOptions
+             * @instance
+             */
+            MessageOptions.prototype.mapEntry = false;
+
+            /**
+             * MessageOptions uninterpretedOption.
+             * @member {Array.<google.protobuf.IUninterpretedOption>}uninterpretedOption
+             * @memberof google.protobuf.MessageOptions
+             * @instance
+             */
+            MessageOptions.prototype.uninterpretedOption = $util.emptyArray;
+
+            /**
+             * Creates a new MessageOptions instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.MessageOptions
+             * @static
+             * @param {google.protobuf.IMessageOptions=} [properties] Properties to set
+             * @returns {google.protobuf.MessageOptions} MessageOptions instance
+             */
+            MessageOptions.create = function create(properties) {
+                return new MessageOptions(properties);
+            };
+
+            /**
+             * Encodes the specified MessageOptions message. Does not implicitly {@link google.protobuf.MessageOptions.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.MessageOptions
+             * @static
+             * @param {google.protobuf.IMessageOptions} message MessageOptions message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            MessageOptions.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.messageSetWireFormat != null && message.hasOwnProperty("messageSetWireFormat"))
+                    writer.uint32(/* id 1, wireType 0 =*/8).bool(message.messageSetWireFormat);
+                if (message.noStandardDescriptorAccessor != null && message.hasOwnProperty("noStandardDescriptorAccessor"))
+                    writer.uint32(/* id 2, wireType 0 =*/16).bool(message.noStandardDescriptorAccessor);
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    writer.uint32(/* id 3, wireType 0 =*/24).bool(message.deprecated);
+                if (message.mapEntry != null && message.hasOwnProperty("mapEntry"))
+                    writer.uint32(/* id 7, wireType 0 =*/56).bool(message.mapEntry);
+                if (message.uninterpretedOption != null && message.uninterpretedOption.length)
+                    for (var i = 0; i < message.uninterpretedOption.length; ++i)
+                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified MessageOptions message, length delimited. Does not implicitly {@link google.protobuf.MessageOptions.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.MessageOptions
+             * @static
+             * @param {google.protobuf.IMessageOptions} message MessageOptions message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            MessageOptions.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a MessageOptions message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.MessageOptions
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.MessageOptions} MessageOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            MessageOptions.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.MessageOptions();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.messageSetWireFormat = reader.bool();
+                        break;
+                    case 2:
+                        message.noStandardDescriptorAccessor = reader.bool();
+                        break;
+                    case 3:
+                        message.deprecated = reader.bool();
+                        break;
+                    case 7:
+                        message.mapEntry = reader.bool();
+                        break;
+                    case 999:
+                        if (!(message.uninterpretedOption && message.uninterpretedOption.length))
+                            message.uninterpretedOption = [];
+                        message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a MessageOptions message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.MessageOptions
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.MessageOptions} MessageOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            MessageOptions.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a MessageOptions message.
+             * @function verify
+             * @memberof google.protobuf.MessageOptions
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            MessageOptions.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.messageSetWireFormat != null && message.hasOwnProperty("messageSetWireFormat"))
+                    if (typeof message.messageSetWireFormat !== "boolean")
+                        return "messageSetWireFormat: boolean expected";
+                if (message.noStandardDescriptorAccessor != null && message.hasOwnProperty("noStandardDescriptorAccessor"))
+                    if (typeof message.noStandardDescriptorAccessor !== "boolean")
+                        return "noStandardDescriptorAccessor: boolean expected";
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    if (typeof message.deprecated !== "boolean")
+                        return "deprecated: boolean expected";
+                if (message.mapEntry != null && message.hasOwnProperty("mapEntry"))
+                    if (typeof message.mapEntry !== "boolean")
+                        return "mapEntry: boolean expected";
+                if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
+                    if (!Array.isArray(message.uninterpretedOption))
+                        return "uninterpretedOption: array expected";
+                    for (var i = 0; i < message.uninterpretedOption.length; ++i) {
+                        var error = $root.google.protobuf.UninterpretedOption.verify(message.uninterpretedOption[i]);
+                        if (error)
+                            return "uninterpretedOption." + error;
+                    }
+                }
+                return null;
+            };
+
+            /**
+             * Creates a MessageOptions message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.MessageOptions
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.MessageOptions} MessageOptions
+             */
+            MessageOptions.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.MessageOptions)
+                    return object;
+                var message = new $root.google.protobuf.MessageOptions();
+                if (object.messageSetWireFormat != null)
+                    message.messageSetWireFormat = Boolean(object.messageSetWireFormat);
+                if (object.noStandardDescriptorAccessor != null)
+                    message.noStandardDescriptorAccessor = Boolean(object.noStandardDescriptorAccessor);
+                if (object.deprecated != null)
+                    message.deprecated = Boolean(object.deprecated);
+                if (object.mapEntry != null)
+                    message.mapEntry = Boolean(object.mapEntry);
+                if (object.uninterpretedOption) {
+                    if (!Array.isArray(object.uninterpretedOption))
+                        throw TypeError(".google.protobuf.MessageOptions.uninterpretedOption: array expected");
+                    message.uninterpretedOption = [];
+                    for (var i = 0; i < object.uninterpretedOption.length; ++i) {
+                        if (typeof object.uninterpretedOption[i] !== "object")
+                            throw TypeError(".google.protobuf.MessageOptions.uninterpretedOption: object expected");
+                        message.uninterpretedOption[i] = $root.google.protobuf.UninterpretedOption.fromObject(object.uninterpretedOption[i]);
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a MessageOptions message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.MessageOptions
+             * @static
+             * @param {google.protobuf.MessageOptions} message MessageOptions
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            MessageOptions.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.uninterpretedOption = [];
+                if (options.defaults) {
+                    object.messageSetWireFormat = false;
+                    object.noStandardDescriptorAccessor = false;
+                    object.deprecated = false;
+                    object.mapEntry = false;
+                }
+                if (message.messageSetWireFormat != null && message.hasOwnProperty("messageSetWireFormat"))
+                    object.messageSetWireFormat = message.messageSetWireFormat;
+                if (message.noStandardDescriptorAccessor != null && message.hasOwnProperty("noStandardDescriptorAccessor"))
+                    object.noStandardDescriptorAccessor = message.noStandardDescriptorAccessor;
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    object.deprecated = message.deprecated;
+                if (message.mapEntry != null && message.hasOwnProperty("mapEntry"))
+                    object.mapEntry = message.mapEntry;
+                if (message.uninterpretedOption && message.uninterpretedOption.length) {
+                    object.uninterpretedOption = [];
+                    for (var j = 0; j < message.uninterpretedOption.length; ++j)
+                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options);
+                }
+                return object;
+            };
+
+            /**
+             * Converts this MessageOptions to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.MessageOptions
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            MessageOptions.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return MessageOptions;
+        })();
+
+        protobuf.FieldOptions = (function() {
+
+            /**
+             * Properties of a FieldOptions.
+             * @memberof google.protobuf
+             * @interface IFieldOptions
+             * @property {google.protobuf.FieldOptions.CType} [ctype] FieldOptions ctype
+             * @property {boolean} [packed] FieldOptions packed
+             * @property {google.protobuf.FieldOptions.JSType} [jstype] FieldOptions jstype
+             * @property {boolean} [lazy] FieldOptions lazy
+             * @property {boolean} [deprecated] FieldOptions deprecated
+             * @property {boolean} [weak] FieldOptions weak
+             * @property {Array.<google.protobuf.IUninterpretedOption>} [uninterpretedOption] FieldOptions uninterpretedOption
+             */
+
+            /**
+             * Constructs a new FieldOptions.
+             * @memberof google.protobuf
+             * @classdesc Represents a FieldOptions.
+             * @constructor
+             * @param {google.protobuf.IFieldOptions=} [properties] Properties to set
+             */
+            function FieldOptions(properties) {
+                this.uninterpretedOption = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * FieldOptions ctype.
+             * @member {google.protobuf.FieldOptions.CType}ctype
+             * @memberof google.protobuf.FieldOptions
+             * @instance
+             */
+            FieldOptions.prototype.ctype = 0;
+
+            /**
+             * FieldOptions packed.
+             * @member {boolean}packed
+             * @memberof google.protobuf.FieldOptions
+             * @instance
+             */
+            FieldOptions.prototype.packed = false;
+
+            /**
+             * FieldOptions jstype.
+             * @member {google.protobuf.FieldOptions.JSType}jstype
+             * @memberof google.protobuf.FieldOptions
+             * @instance
+             */
+            FieldOptions.prototype.jstype = 0;
+
+            /**
+             * FieldOptions lazy.
+             * @member {boolean}lazy
+             * @memberof google.protobuf.FieldOptions
+             * @instance
+             */
+            FieldOptions.prototype.lazy = false;
+
+            /**
+             * FieldOptions deprecated.
+             * @member {boolean}deprecated
+             * @memberof google.protobuf.FieldOptions
+             * @instance
+             */
+            FieldOptions.prototype.deprecated = false;
+
+            /**
+             * FieldOptions weak.
+             * @member {boolean}weak
+             * @memberof google.protobuf.FieldOptions
+             * @instance
+             */
+            FieldOptions.prototype.weak = false;
+
+            /**
+             * FieldOptions uninterpretedOption.
+             * @member {Array.<google.protobuf.IUninterpretedOption>}uninterpretedOption
+             * @memberof google.protobuf.FieldOptions
+             * @instance
+             */
+            FieldOptions.prototype.uninterpretedOption = $util.emptyArray;
+
+            /**
+             * Creates a new FieldOptions instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.FieldOptions
+             * @static
+             * @param {google.protobuf.IFieldOptions=} [properties] Properties to set
+             * @returns {google.protobuf.FieldOptions} FieldOptions instance
+             */
+            FieldOptions.create = function create(properties) {
+                return new FieldOptions(properties);
+            };
+
+            /**
+             * Encodes the specified FieldOptions message. Does not implicitly {@link google.protobuf.FieldOptions.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.FieldOptions
+             * @static
+             * @param {google.protobuf.IFieldOptions} message FieldOptions message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            FieldOptions.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.ctype != null && message.hasOwnProperty("ctype"))
+                    writer.uint32(/* id 1, wireType 0 =*/8).int32(message.ctype);
+                if (message.packed != null && message.hasOwnProperty("packed"))
+                    writer.uint32(/* id 2, wireType 0 =*/16).bool(message.packed);
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    writer.uint32(/* id 3, wireType 0 =*/24).bool(message.deprecated);
+                if (message.lazy != null && message.hasOwnProperty("lazy"))
+                    writer.uint32(/* id 5, wireType 0 =*/40).bool(message.lazy);
+                if (message.jstype != null && message.hasOwnProperty("jstype"))
+                    writer.uint32(/* id 6, wireType 0 =*/48).int32(message.jstype);
+                if (message.weak != null && message.hasOwnProperty("weak"))
+                    writer.uint32(/* id 10, wireType 0 =*/80).bool(message.weak);
+                if (message.uninterpretedOption != null && message.uninterpretedOption.length)
+                    for (var i = 0; i < message.uninterpretedOption.length; ++i)
+                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified FieldOptions message, length delimited. Does not implicitly {@link google.protobuf.FieldOptions.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.FieldOptions
+             * @static
+             * @param {google.protobuf.IFieldOptions} message FieldOptions message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            FieldOptions.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a FieldOptions message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.FieldOptions
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.FieldOptions} FieldOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            FieldOptions.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.FieldOptions();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.ctype = reader.int32();
+                        break;
+                    case 2:
+                        message.packed = reader.bool();
+                        break;
+                    case 6:
+                        message.jstype = reader.int32();
+                        break;
+                    case 5:
+                        message.lazy = reader.bool();
+                        break;
+                    case 3:
+                        message.deprecated = reader.bool();
+                        break;
+                    case 10:
+                        message.weak = reader.bool();
+                        break;
+                    case 999:
+                        if (!(message.uninterpretedOption && message.uninterpretedOption.length))
+                            message.uninterpretedOption = [];
+                        message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a FieldOptions message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.FieldOptions
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.FieldOptions} FieldOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            FieldOptions.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a FieldOptions message.
+             * @function verify
+             * @memberof google.protobuf.FieldOptions
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            FieldOptions.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.ctype != null && message.hasOwnProperty("ctype"))
+                    switch (message.ctype) {
+                    default:
+                        return "ctype: enum value expected";
+                    case 0:
+                    case 1:
+                    case 2:
+                        break;
+                    }
+                if (message.packed != null && message.hasOwnProperty("packed"))
+                    if (typeof message.packed !== "boolean")
+                        return "packed: boolean expected";
+                if (message.jstype != null && message.hasOwnProperty("jstype"))
+                    switch (message.jstype) {
+                    default:
+                        return "jstype: enum value expected";
+                    case 0:
+                    case 1:
+                    case 2:
+                        break;
+                    }
+                if (message.lazy != null && message.hasOwnProperty("lazy"))
+                    if (typeof message.lazy !== "boolean")
+                        return "lazy: boolean expected";
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    if (typeof message.deprecated !== "boolean")
+                        return "deprecated: boolean expected";
+                if (message.weak != null && message.hasOwnProperty("weak"))
+                    if (typeof message.weak !== "boolean")
+                        return "weak: boolean expected";
+                if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
+                    if (!Array.isArray(message.uninterpretedOption))
+                        return "uninterpretedOption: array expected";
+                    for (var i = 0; i < message.uninterpretedOption.length; ++i) {
+                        var error = $root.google.protobuf.UninterpretedOption.verify(message.uninterpretedOption[i]);
+                        if (error)
+                            return "uninterpretedOption." + error;
+                    }
+                }
+                return null;
+            };
+
+            /**
+             * Creates a FieldOptions message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.FieldOptions
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.FieldOptions} FieldOptions
+             */
+            FieldOptions.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.FieldOptions)
+                    return object;
+                var message = new $root.google.protobuf.FieldOptions();
+                switch (object.ctype) {
+                case "STRING":
+                case 0:
+                    message.ctype = 0;
+                    break;
+                case "CORD":
+                case 1:
+                    message.ctype = 1;
+                    break;
+                case "STRING_PIECE":
+                case 2:
+                    message.ctype = 2;
+                    break;
+                }
+                if (object.packed != null)
+                    message.packed = Boolean(object.packed);
+                switch (object.jstype) {
+                case "JS_NORMAL":
+                case 0:
+                    message.jstype = 0;
+                    break;
+                case "JS_STRING":
+                case 1:
+                    message.jstype = 1;
+                    break;
+                case "JS_NUMBER":
+                case 2:
+                    message.jstype = 2;
+                    break;
+                }
+                if (object.lazy != null)
+                    message.lazy = Boolean(object.lazy);
+                if (object.deprecated != null)
+                    message.deprecated = Boolean(object.deprecated);
+                if (object.weak != null)
+                    message.weak = Boolean(object.weak);
+                if (object.uninterpretedOption) {
+                    if (!Array.isArray(object.uninterpretedOption))
+                        throw TypeError(".google.protobuf.FieldOptions.uninterpretedOption: array expected");
+                    message.uninterpretedOption = [];
+                    for (var i = 0; i < object.uninterpretedOption.length; ++i) {
+                        if (typeof object.uninterpretedOption[i] !== "object")
+                            throw TypeError(".google.protobuf.FieldOptions.uninterpretedOption: object expected");
+                        message.uninterpretedOption[i] = $root.google.protobuf.UninterpretedOption.fromObject(object.uninterpretedOption[i]);
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a FieldOptions message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.FieldOptions
+             * @static
+             * @param {google.protobuf.FieldOptions} message FieldOptions
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            FieldOptions.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.uninterpretedOption = [];
+                if (options.defaults) {
+                    object.ctype = options.enums === String ? "STRING" : 0;
+                    object.packed = false;
+                    object.deprecated = false;
+                    object.lazy = false;
+                    object.jstype = options.enums === String ? "JS_NORMAL" : 0;
+                    object.weak = false;
+                }
+                if (message.ctype != null && message.hasOwnProperty("ctype"))
+                    object.ctype = options.enums === String ? $root.google.protobuf.FieldOptions.CType[message.ctype] : message.ctype;
+                if (message.packed != null && message.hasOwnProperty("packed"))
+                    object.packed = message.packed;
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    object.deprecated = message.deprecated;
+                if (message.lazy != null && message.hasOwnProperty("lazy"))
+                    object.lazy = message.lazy;
+                if (message.jstype != null && message.hasOwnProperty("jstype"))
+                    object.jstype = options.enums === String ? $root.google.protobuf.FieldOptions.JSType[message.jstype] : message.jstype;
+                if (message.weak != null && message.hasOwnProperty("weak"))
+                    object.weak = message.weak;
+                if (message.uninterpretedOption && message.uninterpretedOption.length) {
+                    object.uninterpretedOption = [];
+                    for (var j = 0; j < message.uninterpretedOption.length; ++j)
+                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options);
+                }
+                return object;
+            };
+
+            /**
+             * Converts this FieldOptions to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.FieldOptions
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            FieldOptions.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            /**
+             * CType enum.
+             * @enum {string}
+             * @property {number} STRING=0 STRING value
+             * @property {number} CORD=1 CORD value
+             * @property {number} STRING_PIECE=2 STRING_PIECE value
+             */
+            FieldOptions.CType = (function() {
+                var valuesById = {}, values = Object.create(valuesById);
+                values[valuesById[0] = "STRING"] = 0;
+                values[valuesById[1] = "CORD"] = 1;
+                values[valuesById[2] = "STRING_PIECE"] = 2;
+                return values;
+            })();
+
+            /**
+             * JSType enum.
+             * @enum {string}
+             * @property {number} JS_NORMAL=0 JS_NORMAL value
+             * @property {number} JS_STRING=1 JS_STRING value
+             * @property {number} JS_NUMBER=2 JS_NUMBER value
+             */
+            FieldOptions.JSType = (function() {
+                var valuesById = {}, values = Object.create(valuesById);
+                values[valuesById[0] = "JS_NORMAL"] = 0;
+                values[valuesById[1] = "JS_STRING"] = 1;
+                values[valuesById[2] = "JS_NUMBER"] = 2;
+                return values;
+            })();
+
+            return FieldOptions;
+        })();
+
+        protobuf.OneofOptions = (function() {
+
+            /**
+             * Properties of an OneofOptions.
+             * @memberof google.protobuf
+             * @interface IOneofOptions
+             * @property {Array.<google.protobuf.IUninterpretedOption>} [uninterpretedOption] OneofOptions uninterpretedOption
+             */
+
+            /**
+             * Constructs a new OneofOptions.
+             * @memberof google.protobuf
+             * @classdesc Represents an OneofOptions.
+             * @constructor
+             * @param {google.protobuf.IOneofOptions=} [properties] Properties to set
+             */
+            function OneofOptions(properties) {
+                this.uninterpretedOption = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * OneofOptions uninterpretedOption.
+             * @member {Array.<google.protobuf.IUninterpretedOption>}uninterpretedOption
+             * @memberof google.protobuf.OneofOptions
+             * @instance
+             */
+            OneofOptions.prototype.uninterpretedOption = $util.emptyArray;
+
+            /**
+             * Creates a new OneofOptions instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.OneofOptions
+             * @static
+             * @param {google.protobuf.IOneofOptions=} [properties] Properties to set
+             * @returns {google.protobuf.OneofOptions} OneofOptions instance
+             */
+            OneofOptions.create = function create(properties) {
+                return new OneofOptions(properties);
+            };
+
+            /**
+             * Encodes the specified OneofOptions message. Does not implicitly {@link google.protobuf.OneofOptions.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.OneofOptions
+             * @static
+             * @param {google.protobuf.IOneofOptions} message OneofOptions message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            OneofOptions.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.uninterpretedOption != null && message.uninterpretedOption.length)
+                    for (var i = 0; i < message.uninterpretedOption.length; ++i)
+                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified OneofOptions message, length delimited. Does not implicitly {@link google.protobuf.OneofOptions.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.OneofOptions
+             * @static
+             * @param {google.protobuf.IOneofOptions} message OneofOptions message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            OneofOptions.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes an OneofOptions message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.OneofOptions
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.OneofOptions} OneofOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            OneofOptions.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.OneofOptions();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 999:
+                        if (!(message.uninterpretedOption && message.uninterpretedOption.length))
+                            message.uninterpretedOption = [];
+                        message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes an OneofOptions message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.OneofOptions
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.OneofOptions} OneofOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            OneofOptions.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies an OneofOptions message.
+             * @function verify
+             * @memberof google.protobuf.OneofOptions
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            OneofOptions.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
+                    if (!Array.isArray(message.uninterpretedOption))
+                        return "uninterpretedOption: array expected";
+                    for (var i = 0; i < message.uninterpretedOption.length; ++i) {
+                        var error = $root.google.protobuf.UninterpretedOption.verify(message.uninterpretedOption[i]);
+                        if (error)
+                            return "uninterpretedOption." + error;
+                    }
+                }
+                return null;
+            };
+
+            /**
+             * Creates an OneofOptions message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.OneofOptions
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.OneofOptions} OneofOptions
+             */
+            OneofOptions.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.OneofOptions)
+                    return object;
+                var message = new $root.google.protobuf.OneofOptions();
+                if (object.uninterpretedOption) {
+                    if (!Array.isArray(object.uninterpretedOption))
+                        throw TypeError(".google.protobuf.OneofOptions.uninterpretedOption: array expected");
+                    message.uninterpretedOption = [];
+                    for (var i = 0; i < object.uninterpretedOption.length; ++i) {
+                        if (typeof object.uninterpretedOption[i] !== "object")
+                            throw TypeError(".google.protobuf.OneofOptions.uninterpretedOption: object expected");
+                        message.uninterpretedOption[i] = $root.google.protobuf.UninterpretedOption.fromObject(object.uninterpretedOption[i]);
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from an OneofOptions message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.OneofOptions
+             * @static
+             * @param {google.protobuf.OneofOptions} message OneofOptions
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            OneofOptions.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.uninterpretedOption = [];
+                if (message.uninterpretedOption && message.uninterpretedOption.length) {
+                    object.uninterpretedOption = [];
+                    for (var j = 0; j < message.uninterpretedOption.length; ++j)
+                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options);
+                }
+                return object;
+            };
+
+            /**
+             * Converts this OneofOptions to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.OneofOptions
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            OneofOptions.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return OneofOptions;
+        })();
+
+        protobuf.EnumOptions = (function() {
+
+            /**
+             * Properties of an EnumOptions.
+             * @memberof google.protobuf
+             * @interface IEnumOptions
+             * @property {boolean} [allowAlias] EnumOptions allowAlias
+             * @property {boolean} [deprecated] EnumOptions deprecated
+             * @property {Array.<google.protobuf.IUninterpretedOption>} [uninterpretedOption] EnumOptions uninterpretedOption
+             */
+
+            /**
+             * Constructs a new EnumOptions.
+             * @memberof google.protobuf
+             * @classdesc Represents an EnumOptions.
+             * @constructor
+             * @param {google.protobuf.IEnumOptions=} [properties] Properties to set
+             */
+            function EnumOptions(properties) {
+                this.uninterpretedOption = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * EnumOptions allowAlias.
+             * @member {boolean}allowAlias
+             * @memberof google.protobuf.EnumOptions
+             * @instance
+             */
+            EnumOptions.prototype.allowAlias = false;
+
+            /**
+             * EnumOptions deprecated.
+             * @member {boolean}deprecated
+             * @memberof google.protobuf.EnumOptions
+             * @instance
+             */
+            EnumOptions.prototype.deprecated = false;
+
+            /**
+             * EnumOptions uninterpretedOption.
+             * @member {Array.<google.protobuf.IUninterpretedOption>}uninterpretedOption
+             * @memberof google.protobuf.EnumOptions
+             * @instance
+             */
+            EnumOptions.prototype.uninterpretedOption = $util.emptyArray;
+
+            /**
+             * Creates a new EnumOptions instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.EnumOptions
+             * @static
+             * @param {google.protobuf.IEnumOptions=} [properties] Properties to set
+             * @returns {google.protobuf.EnumOptions} EnumOptions instance
+             */
+            EnumOptions.create = function create(properties) {
+                return new EnumOptions(properties);
+            };
+
+            /**
+             * Encodes the specified EnumOptions message. Does not implicitly {@link google.protobuf.EnumOptions.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.EnumOptions
+             * @static
+             * @param {google.protobuf.IEnumOptions} message EnumOptions message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            EnumOptions.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.allowAlias != null && message.hasOwnProperty("allowAlias"))
+                    writer.uint32(/* id 2, wireType 0 =*/16).bool(message.allowAlias);
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    writer.uint32(/* id 3, wireType 0 =*/24).bool(message.deprecated);
+                if (message.uninterpretedOption != null && message.uninterpretedOption.length)
+                    for (var i = 0; i < message.uninterpretedOption.length; ++i)
+                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified EnumOptions message, length delimited. Does not implicitly {@link google.protobuf.EnumOptions.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.EnumOptions
+             * @static
+             * @param {google.protobuf.IEnumOptions} message EnumOptions message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            EnumOptions.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes an EnumOptions message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.EnumOptions
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.EnumOptions} EnumOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            EnumOptions.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.EnumOptions();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 2:
+                        message.allowAlias = reader.bool();
+                        break;
+                    case 3:
+                        message.deprecated = reader.bool();
+                        break;
+                    case 999:
+                        if (!(message.uninterpretedOption && message.uninterpretedOption.length))
+                            message.uninterpretedOption = [];
+                        message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes an EnumOptions message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.EnumOptions
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.EnumOptions} EnumOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            EnumOptions.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies an EnumOptions message.
+             * @function verify
+             * @memberof google.protobuf.EnumOptions
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            EnumOptions.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.allowAlias != null && message.hasOwnProperty("allowAlias"))
+                    if (typeof message.allowAlias !== "boolean")
+                        return "allowAlias: boolean expected";
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    if (typeof message.deprecated !== "boolean")
+                        return "deprecated: boolean expected";
+                if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
+                    if (!Array.isArray(message.uninterpretedOption))
+                        return "uninterpretedOption: array expected";
+                    for (var i = 0; i < message.uninterpretedOption.length; ++i) {
+                        var error = $root.google.protobuf.UninterpretedOption.verify(message.uninterpretedOption[i]);
+                        if (error)
+                            return "uninterpretedOption." + error;
+                    }
+                }
+                return null;
+            };
+
+            /**
+             * Creates an EnumOptions message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.EnumOptions
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.EnumOptions} EnumOptions
+             */
+            EnumOptions.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.EnumOptions)
+                    return object;
+                var message = new $root.google.protobuf.EnumOptions();
+                if (object.allowAlias != null)
+                    message.allowAlias = Boolean(object.allowAlias);
+                if (object.deprecated != null)
+                    message.deprecated = Boolean(object.deprecated);
+                if (object.uninterpretedOption) {
+                    if (!Array.isArray(object.uninterpretedOption))
+                        throw TypeError(".google.protobuf.EnumOptions.uninterpretedOption: array expected");
+                    message.uninterpretedOption = [];
+                    for (var i = 0; i < object.uninterpretedOption.length; ++i) {
+                        if (typeof object.uninterpretedOption[i] !== "object")
+                            throw TypeError(".google.protobuf.EnumOptions.uninterpretedOption: object expected");
+                        message.uninterpretedOption[i] = $root.google.protobuf.UninterpretedOption.fromObject(object.uninterpretedOption[i]);
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from an EnumOptions message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.EnumOptions
+             * @static
+             * @param {google.protobuf.EnumOptions} message EnumOptions
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            EnumOptions.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.uninterpretedOption = [];
+                if (options.defaults) {
+                    object.allowAlias = false;
+                    object.deprecated = false;
+                }
+                if (message.allowAlias != null && message.hasOwnProperty("allowAlias"))
+                    object.allowAlias = message.allowAlias;
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    object.deprecated = message.deprecated;
+                if (message.uninterpretedOption && message.uninterpretedOption.length) {
+                    object.uninterpretedOption = [];
+                    for (var j = 0; j < message.uninterpretedOption.length; ++j)
+                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options);
+                }
+                return object;
+            };
+
+            /**
+             * Converts this EnumOptions to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.EnumOptions
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            EnumOptions.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return EnumOptions;
+        })();
+
+        protobuf.EnumValueOptions = (function() {
+
+            /**
+             * Properties of an EnumValueOptions.
+             * @memberof google.protobuf
+             * @interface IEnumValueOptions
+             * @property {boolean} [deprecated] EnumValueOptions deprecated
+             * @property {Array.<google.protobuf.IUninterpretedOption>} [uninterpretedOption] EnumValueOptions uninterpretedOption
+             */
+
+            /**
+             * Constructs a new EnumValueOptions.
+             * @memberof google.protobuf
+             * @classdesc Represents an EnumValueOptions.
+             * @constructor
+             * @param {google.protobuf.IEnumValueOptions=} [properties] Properties to set
+             */
+            function EnumValueOptions(properties) {
+                this.uninterpretedOption = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * EnumValueOptions deprecated.
+             * @member {boolean}deprecated
+             * @memberof google.protobuf.EnumValueOptions
+             * @instance
+             */
+            EnumValueOptions.prototype.deprecated = false;
+
+            /**
+             * EnumValueOptions uninterpretedOption.
+             * @member {Array.<google.protobuf.IUninterpretedOption>}uninterpretedOption
+             * @memberof google.protobuf.EnumValueOptions
+             * @instance
+             */
+            EnumValueOptions.prototype.uninterpretedOption = $util.emptyArray;
+
+            /**
+             * Creates a new EnumValueOptions instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.EnumValueOptions
+             * @static
+             * @param {google.protobuf.IEnumValueOptions=} [properties] Properties to set
+             * @returns {google.protobuf.EnumValueOptions} EnumValueOptions instance
+             */
+            EnumValueOptions.create = function create(properties) {
+                return new EnumValueOptions(properties);
+            };
+
+            /**
+             * Encodes the specified EnumValueOptions message. Does not implicitly {@link google.protobuf.EnumValueOptions.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.EnumValueOptions
+             * @static
+             * @param {google.protobuf.IEnumValueOptions} message EnumValueOptions message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            EnumValueOptions.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    writer.uint32(/* id 1, wireType 0 =*/8).bool(message.deprecated);
+                if (message.uninterpretedOption != null && message.uninterpretedOption.length)
+                    for (var i = 0; i < message.uninterpretedOption.length; ++i)
+                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified EnumValueOptions message, length delimited. Does not implicitly {@link google.protobuf.EnumValueOptions.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.EnumValueOptions
+             * @static
+             * @param {google.protobuf.IEnumValueOptions} message EnumValueOptions message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            EnumValueOptions.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes an EnumValueOptions message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.EnumValueOptions
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.EnumValueOptions} EnumValueOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            EnumValueOptions.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.EnumValueOptions();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.deprecated = reader.bool();
+                        break;
+                    case 999:
+                        if (!(message.uninterpretedOption && message.uninterpretedOption.length))
+                            message.uninterpretedOption = [];
+                        message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes an EnumValueOptions message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.EnumValueOptions
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.EnumValueOptions} EnumValueOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            EnumValueOptions.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies an EnumValueOptions message.
+             * @function verify
+             * @memberof google.protobuf.EnumValueOptions
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            EnumValueOptions.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    if (typeof message.deprecated !== "boolean")
+                        return "deprecated: boolean expected";
+                if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
+                    if (!Array.isArray(message.uninterpretedOption))
+                        return "uninterpretedOption: array expected";
+                    for (var i = 0; i < message.uninterpretedOption.length; ++i) {
+                        var error = $root.google.protobuf.UninterpretedOption.verify(message.uninterpretedOption[i]);
+                        if (error)
+                            return "uninterpretedOption." + error;
+                    }
+                }
+                return null;
+            };
+
+            /**
+             * Creates an EnumValueOptions message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.EnumValueOptions
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.EnumValueOptions} EnumValueOptions
+             */
+            EnumValueOptions.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.EnumValueOptions)
+                    return object;
+                var message = new $root.google.protobuf.EnumValueOptions();
+                if (object.deprecated != null)
+                    message.deprecated = Boolean(object.deprecated);
+                if (object.uninterpretedOption) {
+                    if (!Array.isArray(object.uninterpretedOption))
+                        throw TypeError(".google.protobuf.EnumValueOptions.uninterpretedOption: array expected");
+                    message.uninterpretedOption = [];
+                    for (var i = 0; i < object.uninterpretedOption.length; ++i) {
+                        if (typeof object.uninterpretedOption[i] !== "object")
+                            throw TypeError(".google.protobuf.EnumValueOptions.uninterpretedOption: object expected");
+                        message.uninterpretedOption[i] = $root.google.protobuf.UninterpretedOption.fromObject(object.uninterpretedOption[i]);
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from an EnumValueOptions message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.EnumValueOptions
+             * @static
+             * @param {google.protobuf.EnumValueOptions} message EnumValueOptions
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            EnumValueOptions.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.uninterpretedOption = [];
+                if (options.defaults)
+                    object.deprecated = false;
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    object.deprecated = message.deprecated;
+                if (message.uninterpretedOption && message.uninterpretedOption.length) {
+                    object.uninterpretedOption = [];
+                    for (var j = 0; j < message.uninterpretedOption.length; ++j)
+                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options);
+                }
+                return object;
+            };
+
+            /**
+             * Converts this EnumValueOptions to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.EnumValueOptions
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            EnumValueOptions.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return EnumValueOptions;
+        })();
+
+        protobuf.ServiceOptions = (function() {
+
+            /**
+             * Properties of a ServiceOptions.
+             * @memberof google.protobuf
+             * @interface IServiceOptions
+             * @property {boolean} [deprecated] ServiceOptions deprecated
+             * @property {Array.<google.protobuf.IUninterpretedOption>} [uninterpretedOption] ServiceOptions uninterpretedOption
+             */
+
+            /**
+             * Constructs a new ServiceOptions.
+             * @memberof google.protobuf
+             * @classdesc Represents a ServiceOptions.
+             * @constructor
+             * @param {google.protobuf.IServiceOptions=} [properties] Properties to set
+             */
+            function ServiceOptions(properties) {
+                this.uninterpretedOption = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * ServiceOptions deprecated.
+             * @member {boolean}deprecated
+             * @memberof google.protobuf.ServiceOptions
+             * @instance
+             */
+            ServiceOptions.prototype.deprecated = false;
+
+            /**
+             * ServiceOptions uninterpretedOption.
+             * @member {Array.<google.protobuf.IUninterpretedOption>}uninterpretedOption
+             * @memberof google.protobuf.ServiceOptions
+             * @instance
+             */
+            ServiceOptions.prototype.uninterpretedOption = $util.emptyArray;
+
+            /**
+             * Creates a new ServiceOptions instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.ServiceOptions
+             * @static
+             * @param {google.protobuf.IServiceOptions=} [properties] Properties to set
+             * @returns {google.protobuf.ServiceOptions} ServiceOptions instance
+             */
+            ServiceOptions.create = function create(properties) {
+                return new ServiceOptions(properties);
+            };
+
+            /**
+             * Encodes the specified ServiceOptions message. Does not implicitly {@link google.protobuf.ServiceOptions.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.ServiceOptions
+             * @static
+             * @param {google.protobuf.IServiceOptions} message ServiceOptions message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            ServiceOptions.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    writer.uint32(/* id 33, wireType 0 =*/264).bool(message.deprecated);
+                if (message.uninterpretedOption != null && message.uninterpretedOption.length)
+                    for (var i = 0; i < message.uninterpretedOption.length; ++i)
+                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified ServiceOptions message, length delimited. Does not implicitly {@link google.protobuf.ServiceOptions.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.ServiceOptions
+             * @static
+             * @param {google.protobuf.IServiceOptions} message ServiceOptions message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            ServiceOptions.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a ServiceOptions message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.ServiceOptions
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.ServiceOptions} ServiceOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            ServiceOptions.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.ServiceOptions();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 33:
+                        message.deprecated = reader.bool();
+                        break;
+                    case 999:
+                        if (!(message.uninterpretedOption && message.uninterpretedOption.length))
+                            message.uninterpretedOption = [];
+                        message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a ServiceOptions message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.ServiceOptions
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.ServiceOptions} ServiceOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            ServiceOptions.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a ServiceOptions message.
+             * @function verify
+             * @memberof google.protobuf.ServiceOptions
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            ServiceOptions.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    if (typeof message.deprecated !== "boolean")
+                        return "deprecated: boolean expected";
+                if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
+                    if (!Array.isArray(message.uninterpretedOption))
+                        return "uninterpretedOption: array expected";
+                    for (var i = 0; i < message.uninterpretedOption.length; ++i) {
+                        var error = $root.google.protobuf.UninterpretedOption.verify(message.uninterpretedOption[i]);
+                        if (error)
+                            return "uninterpretedOption." + error;
+                    }
+                }
+                return null;
+            };
+
+            /**
+             * Creates a ServiceOptions message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.ServiceOptions
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.ServiceOptions} ServiceOptions
+             */
+            ServiceOptions.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.ServiceOptions)
+                    return object;
+                var message = new $root.google.protobuf.ServiceOptions();
+                if (object.deprecated != null)
+                    message.deprecated = Boolean(object.deprecated);
+                if (object.uninterpretedOption) {
+                    if (!Array.isArray(object.uninterpretedOption))
+                        throw TypeError(".google.protobuf.ServiceOptions.uninterpretedOption: array expected");
+                    message.uninterpretedOption = [];
+                    for (var i = 0; i < object.uninterpretedOption.length; ++i) {
+                        if (typeof object.uninterpretedOption[i] !== "object")
+                            throw TypeError(".google.protobuf.ServiceOptions.uninterpretedOption: object expected");
+                        message.uninterpretedOption[i] = $root.google.protobuf.UninterpretedOption.fromObject(object.uninterpretedOption[i]);
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a ServiceOptions message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.ServiceOptions
+             * @static
+             * @param {google.protobuf.ServiceOptions} message ServiceOptions
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            ServiceOptions.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.uninterpretedOption = [];
+                if (options.defaults)
+                    object.deprecated = false;
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    object.deprecated = message.deprecated;
+                if (message.uninterpretedOption && message.uninterpretedOption.length) {
+                    object.uninterpretedOption = [];
+                    for (var j = 0; j < message.uninterpretedOption.length; ++j)
+                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options);
+                }
+                return object;
+            };
+
+            /**
+             * Converts this ServiceOptions to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.ServiceOptions
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            ServiceOptions.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return ServiceOptions;
+        })();
+
+        protobuf.MethodOptions = (function() {
+
+            /**
+             * Properties of a MethodOptions.
+             * @memberof google.protobuf
+             * @interface IMethodOptions
+             * @property {boolean} [deprecated] MethodOptions deprecated
+             * @property {Array.<google.protobuf.IUninterpretedOption>} [uninterpretedOption] MethodOptions uninterpretedOption
+             * @property {google.api.IHttpRule} [".google.api.http"] MethodOptions .google.api.http
+             */
+
+            /**
+             * Constructs a new MethodOptions.
+             * @memberof google.protobuf
+             * @classdesc Represents a MethodOptions.
+             * @constructor
+             * @param {google.protobuf.IMethodOptions=} [properties] Properties to set
+             */
+            function MethodOptions(properties) {
+                this.uninterpretedOption = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * MethodOptions deprecated.
+             * @member {boolean}deprecated
+             * @memberof google.protobuf.MethodOptions
+             * @instance
+             */
+            MethodOptions.prototype.deprecated = false;
+
+            /**
+             * MethodOptions uninterpretedOption.
+             * @member {Array.<google.protobuf.IUninterpretedOption>}uninterpretedOption
+             * @memberof google.protobuf.MethodOptions
+             * @instance
+             */
+            MethodOptions.prototype.uninterpretedOption = $util.emptyArray;
+
+            /**
+             * MethodOptions .google.api.http.
+             * @member {(google.api.IHttpRule|null|undefined)}.google.api.http
+             * @memberof google.protobuf.MethodOptions
+             * @instance
+             */
+            MethodOptions.prototype[".google.api.http"] = null;
+
+            /**
+             * Creates a new MethodOptions instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.MethodOptions
+             * @static
+             * @param {google.protobuf.IMethodOptions=} [properties] Properties to set
+             * @returns {google.protobuf.MethodOptions} MethodOptions instance
+             */
+            MethodOptions.create = function create(properties) {
+                return new MethodOptions(properties);
+            };
+
+            /**
+             * Encodes the specified MethodOptions message. Does not implicitly {@link google.protobuf.MethodOptions.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.MethodOptions
+             * @static
+             * @param {google.protobuf.IMethodOptions} message MethodOptions message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            MethodOptions.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    writer.uint32(/* id 33, wireType 0 =*/264).bool(message.deprecated);
+                if (message.uninterpretedOption != null && message.uninterpretedOption.length)
+                    for (var i = 0; i < message.uninterpretedOption.length; ++i)
+                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                if (message[".google.api.http"] != null && message.hasOwnProperty(".google.api.http"))
+                    $root.google.api.HttpRule.encode(message[".google.api.http"], writer.uint32(/* id 72295728, wireType 2 =*/578365826).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified MethodOptions message, length delimited. Does not implicitly {@link google.protobuf.MethodOptions.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.MethodOptions
+             * @static
+             * @param {google.protobuf.IMethodOptions} message MethodOptions message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            MethodOptions.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a MethodOptions message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.MethodOptions
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.MethodOptions} MethodOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            MethodOptions.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.MethodOptions();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 33:
+                        message.deprecated = reader.bool();
+                        break;
+                    case 999:
+                        if (!(message.uninterpretedOption && message.uninterpretedOption.length))
+                            message.uninterpretedOption = [];
+                        message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
+                        break;
+                    case 72295728:
+                        message[".google.api.http"] = $root.google.api.HttpRule.decode(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a MethodOptions message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.MethodOptions
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.MethodOptions} MethodOptions
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            MethodOptions.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a MethodOptions message.
+             * @function verify
+             * @memberof google.protobuf.MethodOptions
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            MethodOptions.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    if (typeof message.deprecated !== "boolean")
+                        return "deprecated: boolean expected";
+                if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
+                    if (!Array.isArray(message.uninterpretedOption))
+                        return "uninterpretedOption: array expected";
+                    for (var i = 0; i < message.uninterpretedOption.length; ++i) {
+                        var error = $root.google.protobuf.UninterpretedOption.verify(message.uninterpretedOption[i]);
+                        if (error)
+                            return "uninterpretedOption." + error;
+                    }
+                }
+                if (message[".google.api.http"] != null && message.hasOwnProperty(".google.api.http")) {
+                    error = $root.google.api.HttpRule.verify(message[".google.api.http"]);
+                    if (error)
+                        return ".google.api.http." + error;
+                }
+                return null;
+            };
+
+            /**
+             * Creates a MethodOptions message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.MethodOptions
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.MethodOptions} MethodOptions
+             */
+            MethodOptions.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.MethodOptions)
+                    return object;
+                var message = new $root.google.protobuf.MethodOptions();
+                if (object.deprecated != null)
+                    message.deprecated = Boolean(object.deprecated);
+                if (object.uninterpretedOption) {
+                    if (!Array.isArray(object.uninterpretedOption))
+                        throw TypeError(".google.protobuf.MethodOptions.uninterpretedOption: array expected");
+                    message.uninterpretedOption = [];
+                    for (var i = 0; i < object.uninterpretedOption.length; ++i) {
+                        if (typeof object.uninterpretedOption[i] !== "object")
+                            throw TypeError(".google.protobuf.MethodOptions.uninterpretedOption: object expected");
+                        message.uninterpretedOption[i] = $root.google.protobuf.UninterpretedOption.fromObject(object.uninterpretedOption[i]);
+                    }
+                }
+                if (object[".google.api.http"] != null) {
+                    if (typeof object[".google.api.http"] !== "object")
+                        throw TypeError(".google.protobuf.MethodOptions..google.api.http: object expected");
+                    message[".google.api.http"] = $root.google.api.HttpRule.fromObject(object[".google.api.http"]);
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a MethodOptions message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.MethodOptions
+             * @static
+             * @param {google.protobuf.MethodOptions} message MethodOptions
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            MethodOptions.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.uninterpretedOption = [];
+                if (options.defaults) {
+                    object.deprecated = false;
+                    object[".google.api.http"] = null;
+                }
+                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                    object.deprecated = message.deprecated;
+                if (message.uninterpretedOption && message.uninterpretedOption.length) {
+                    object.uninterpretedOption = [];
+                    for (var j = 0; j < message.uninterpretedOption.length; ++j)
+                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options);
+                }
+                if (message[".google.api.http"] != null && message.hasOwnProperty(".google.api.http"))
+                    object[".google.api.http"] = $root.google.api.HttpRule.toObject(message[".google.api.http"], options);
+                return object;
+            };
+
+            /**
+             * Converts this MethodOptions to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.MethodOptions
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            MethodOptions.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return MethodOptions;
+        })();
+
+        protobuf.UninterpretedOption = (function() {
+
+            /**
+             * Properties of an UninterpretedOption.
+             * @memberof google.protobuf
+             * @interface IUninterpretedOption
+             * @property {Array.<google.protobuf.UninterpretedOption.INamePart>} [name] UninterpretedOption name
+             * @property {string} [identifierValue] UninterpretedOption identifierValue
+             * @property {number|Long} [positiveIntValue] UninterpretedOption positiveIntValue
+             * @property {number|Long} [negativeIntValue] UninterpretedOption negativeIntValue
+             * @property {number} [doubleValue] UninterpretedOption doubleValue
+             * @property {Uint8Array} [stringValue] UninterpretedOption stringValue
+             * @property {string} [aggregateValue] UninterpretedOption aggregateValue
+             */
+
+            /**
+             * Constructs a new UninterpretedOption.
+             * @memberof google.protobuf
+             * @classdesc Represents an UninterpretedOption.
+             * @constructor
+             * @param {google.protobuf.IUninterpretedOption=} [properties] Properties to set
+             */
+            function UninterpretedOption(properties) {
+                this.name = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * UninterpretedOption name.
+             * @member {Array.<google.protobuf.UninterpretedOption.INamePart>}name
+             * @memberof google.protobuf.UninterpretedOption
+             * @instance
+             */
+            UninterpretedOption.prototype.name = $util.emptyArray;
+
+            /**
+             * UninterpretedOption identifierValue.
+             * @member {string}identifierValue
+             * @memberof google.protobuf.UninterpretedOption
+             * @instance
+             */
+            UninterpretedOption.prototype.identifierValue = "";
+
+            /**
+             * UninterpretedOption positiveIntValue.
+             * @member {number|Long}positiveIntValue
+             * @memberof google.protobuf.UninterpretedOption
+             * @instance
+             */
+            UninterpretedOption.prototype.positiveIntValue = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+
+            /**
+             * UninterpretedOption negativeIntValue.
+             * @member {number|Long}negativeIntValue
+             * @memberof google.protobuf.UninterpretedOption
+             * @instance
+             */
+            UninterpretedOption.prototype.negativeIntValue = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+
+            /**
+             * UninterpretedOption doubleValue.
+             * @member {number}doubleValue
+             * @memberof google.protobuf.UninterpretedOption
+             * @instance
+             */
+            UninterpretedOption.prototype.doubleValue = 0;
+
+            /**
+             * UninterpretedOption stringValue.
+             * @member {Uint8Array}stringValue
+             * @memberof google.protobuf.UninterpretedOption
+             * @instance
+             */
+            UninterpretedOption.prototype.stringValue = $util.newBuffer([]);
+
+            /**
+             * UninterpretedOption aggregateValue.
+             * @member {string}aggregateValue
+             * @memberof google.protobuf.UninterpretedOption
+             * @instance
+             */
+            UninterpretedOption.prototype.aggregateValue = "";
+
+            /**
+             * Creates a new UninterpretedOption instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.UninterpretedOption
+             * @static
+             * @param {google.protobuf.IUninterpretedOption=} [properties] Properties to set
+             * @returns {google.protobuf.UninterpretedOption} UninterpretedOption instance
+             */
+            UninterpretedOption.create = function create(properties) {
+                return new UninterpretedOption(properties);
+            };
+
+            /**
+             * Encodes the specified UninterpretedOption message. Does not implicitly {@link google.protobuf.UninterpretedOption.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.UninterpretedOption
+             * @static
+             * @param {google.protobuf.IUninterpretedOption} message UninterpretedOption message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            UninterpretedOption.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.name != null && message.name.length)
+                    for (var i = 0; i < message.name.length; ++i)
+                        $root.google.protobuf.UninterpretedOption.NamePart.encode(message.name[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                if (message.identifierValue != null && message.hasOwnProperty("identifierValue"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.identifierValue);
+                if (message.positiveIntValue != null && message.hasOwnProperty("positiveIntValue"))
+                    writer.uint32(/* id 4, wireType 0 =*/32).uint64(message.positiveIntValue);
+                if (message.negativeIntValue != null && message.hasOwnProperty("negativeIntValue"))
+                    writer.uint32(/* id 5, wireType 0 =*/40).int64(message.negativeIntValue);
+                if (message.doubleValue != null && message.hasOwnProperty("doubleValue"))
+                    writer.uint32(/* id 6, wireType 1 =*/49).double(message.doubleValue);
+                if (message.stringValue != null && message.hasOwnProperty("stringValue"))
+                    writer.uint32(/* id 7, wireType 2 =*/58).bytes(message.stringValue);
+                if (message.aggregateValue != null && message.hasOwnProperty("aggregateValue"))
+                    writer.uint32(/* id 8, wireType 2 =*/66).string(message.aggregateValue);
+                return writer;
+            };
+
+            /**
+             * Encodes the specified UninterpretedOption message, length delimited. Does not implicitly {@link google.protobuf.UninterpretedOption.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.UninterpretedOption
+             * @static
+             * @param {google.protobuf.IUninterpretedOption} message UninterpretedOption message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            UninterpretedOption.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes an UninterpretedOption message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.UninterpretedOption
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.UninterpretedOption} UninterpretedOption
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            UninterpretedOption.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.UninterpretedOption();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 2:
+                        if (!(message.name && message.name.length))
+                            message.name = [];
+                        message.name.push($root.google.protobuf.UninterpretedOption.NamePart.decode(reader, reader.uint32()));
+                        break;
+                    case 3:
+                        message.identifierValue = reader.string();
+                        break;
+                    case 4:
+                        message.positiveIntValue = reader.uint64();
+                        break;
+                    case 5:
+                        message.negativeIntValue = reader.int64();
+                        break;
+                    case 6:
+                        message.doubleValue = reader.double();
+                        break;
+                    case 7:
+                        message.stringValue = reader.bytes();
+                        break;
+                    case 8:
+                        message.aggregateValue = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes an UninterpretedOption message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.UninterpretedOption
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.UninterpretedOption} UninterpretedOption
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            UninterpretedOption.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies an UninterpretedOption message.
+             * @function verify
+             * @memberof google.protobuf.UninterpretedOption
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            UninterpretedOption.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.name != null && message.hasOwnProperty("name")) {
+                    if (!Array.isArray(message.name))
+                        return "name: array expected";
+                    for (var i = 0; i < message.name.length; ++i) {
+                        var error = $root.google.protobuf.UninterpretedOption.NamePart.verify(message.name[i]);
+                        if (error)
+                            return "name." + error;
+                    }
+                }
+                if (message.identifierValue != null && message.hasOwnProperty("identifierValue"))
+                    if (!$util.isString(message.identifierValue))
+                        return "identifierValue: string expected";
+                if (message.positiveIntValue != null && message.hasOwnProperty("positiveIntValue"))
+                    if (!$util.isInteger(message.positiveIntValue) && !(message.positiveIntValue && $util.isInteger(message.positiveIntValue.low) && $util.isInteger(message.positiveIntValue.high)))
+                        return "positiveIntValue: integer|Long expected";
+                if (message.negativeIntValue != null && message.hasOwnProperty("negativeIntValue"))
+                    if (!$util.isInteger(message.negativeIntValue) && !(message.negativeIntValue && $util.isInteger(message.negativeIntValue.low) && $util.isInteger(message.negativeIntValue.high)))
+                        return "negativeIntValue: integer|Long expected";
+                if (message.doubleValue != null && message.hasOwnProperty("doubleValue"))
+                    if (typeof message.doubleValue !== "number")
+                        return "doubleValue: number expected";
+                if (message.stringValue != null && message.hasOwnProperty("stringValue"))
+                    if (!(message.stringValue && typeof message.stringValue.length === "number" || $util.isString(message.stringValue)))
+                        return "stringValue: buffer expected";
+                if (message.aggregateValue != null && message.hasOwnProperty("aggregateValue"))
+                    if (!$util.isString(message.aggregateValue))
+                        return "aggregateValue: string expected";
+                return null;
+            };
+
+            /**
+             * Creates an UninterpretedOption message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.UninterpretedOption
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.UninterpretedOption} UninterpretedOption
+             */
+            UninterpretedOption.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.UninterpretedOption)
+                    return object;
+                var message = new $root.google.protobuf.UninterpretedOption();
+                if (object.name) {
+                    if (!Array.isArray(object.name))
+                        throw TypeError(".google.protobuf.UninterpretedOption.name: array expected");
+                    message.name = [];
+                    for (var i = 0; i < object.name.length; ++i) {
+                        if (typeof object.name[i] !== "object")
+                            throw TypeError(".google.protobuf.UninterpretedOption.name: object expected");
+                        message.name[i] = $root.google.protobuf.UninterpretedOption.NamePart.fromObject(object.name[i]);
+                    }
+                }
+                if (object.identifierValue != null)
+                    message.identifierValue = String(object.identifierValue);
+                if (object.positiveIntValue != null)
+                    if ($util.Long)
+                        (message.positiveIntValue = $util.Long.fromValue(object.positiveIntValue)).unsigned = true;
+                    else if (typeof object.positiveIntValue === "string")
+                        message.positiveIntValue = parseInt(object.positiveIntValue, 10);
+                    else if (typeof object.positiveIntValue === "number")
+                        message.positiveIntValue = object.positiveIntValue;
+                    else if (typeof object.positiveIntValue === "object")
+                        message.positiveIntValue = new $util.LongBits(object.positiveIntValue.low >>> 0, object.positiveIntValue.high >>> 0).toNumber(true);
+                if (object.negativeIntValue != null)
+                    if ($util.Long)
+                        (message.negativeIntValue = $util.Long.fromValue(object.negativeIntValue)).unsigned = false;
+                    else if (typeof object.negativeIntValue === "string")
+                        message.negativeIntValue = parseInt(object.negativeIntValue, 10);
+                    else if (typeof object.negativeIntValue === "number")
+                        message.negativeIntValue = object.negativeIntValue;
+                    else if (typeof object.negativeIntValue === "object")
+                        message.negativeIntValue = new $util.LongBits(object.negativeIntValue.low >>> 0, object.negativeIntValue.high >>> 0).toNumber();
+                if (object.doubleValue != null)
+                    message.doubleValue = Number(object.doubleValue);
+                if (object.stringValue != null)
+                    if (typeof object.stringValue === "string")
+                        $util.base64.decode(object.stringValue, message.stringValue = $util.newBuffer($util.base64.length(object.stringValue)), 0);
+                    else if (object.stringValue.length)
+                        message.stringValue = object.stringValue;
+                if (object.aggregateValue != null)
+                    message.aggregateValue = String(object.aggregateValue);
+                return message;
+            };
+
+            /**
+             * Creates a plain object from an UninterpretedOption message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.UninterpretedOption
+             * @static
+             * @param {google.protobuf.UninterpretedOption} message UninterpretedOption
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            UninterpretedOption.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.name = [];
+                if (options.defaults) {
+                    object.identifierValue = "";
+                    if ($util.Long) {
+                        var long = new $util.Long(0, 0, true);
+                        object.positiveIntValue = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                    } else
+                        object.positiveIntValue = options.longs === String ? "0" : 0;
+                    if ($util.Long) {
+                        var long = new $util.Long(0, 0, false);
+                        object.negativeIntValue = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                    } else
+                        object.negativeIntValue = options.longs === String ? "0" : 0;
+                    object.doubleValue = 0;
+                    object.stringValue = options.bytes === String ? "" : [];
+                    object.aggregateValue = "";
+                }
+                if (message.name && message.name.length) {
+                    object.name = [];
+                    for (var j = 0; j < message.name.length; ++j)
+                        object.name[j] = $root.google.protobuf.UninterpretedOption.NamePart.toObject(message.name[j], options);
+                }
+                if (message.identifierValue != null && message.hasOwnProperty("identifierValue"))
+                    object.identifierValue = message.identifierValue;
+                if (message.positiveIntValue != null && message.hasOwnProperty("positiveIntValue"))
+                    if (typeof message.positiveIntValue === "number")
+                        object.positiveIntValue = options.longs === String ? String(message.positiveIntValue) : message.positiveIntValue;
+                    else
+                        object.positiveIntValue = options.longs === String ? $util.Long.prototype.toString.call(message.positiveIntValue) : options.longs === Number ? new $util.LongBits(message.positiveIntValue.low >>> 0, message.positiveIntValue.high >>> 0).toNumber(true) : message.positiveIntValue;
+                if (message.negativeIntValue != null && message.hasOwnProperty("negativeIntValue"))
+                    if (typeof message.negativeIntValue === "number")
+                        object.negativeIntValue = options.longs === String ? String(message.negativeIntValue) : message.negativeIntValue;
+                    else
+                        object.negativeIntValue = options.longs === String ? $util.Long.prototype.toString.call(message.negativeIntValue) : options.longs === Number ? new $util.LongBits(message.negativeIntValue.low >>> 0, message.negativeIntValue.high >>> 0).toNumber() : message.negativeIntValue;
+                if (message.doubleValue != null && message.hasOwnProperty("doubleValue"))
+                    object.doubleValue = options.json && !isFinite(message.doubleValue) ? String(message.doubleValue) : message.doubleValue;
+                if (message.stringValue != null && message.hasOwnProperty("stringValue"))
+                    object.stringValue = options.bytes === String ? $util.base64.encode(message.stringValue, 0, message.stringValue.length) : options.bytes === Array ? Array.prototype.slice.call(message.stringValue) : message.stringValue;
+                if (message.aggregateValue != null && message.hasOwnProperty("aggregateValue"))
+                    object.aggregateValue = message.aggregateValue;
+                return object;
+            };
+
+            /**
+             * Converts this UninterpretedOption to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.UninterpretedOption
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            UninterpretedOption.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            UninterpretedOption.NamePart = (function() {
+
+                /**
+                 * Properties of a NamePart.
+                 * @memberof google.protobuf.UninterpretedOption
+                 * @interface INamePart
+                 * @property {string} namePart NamePart namePart
+                 * @property {boolean} isExtension NamePart isExtension
+                 */
+
+                /**
+                 * Constructs a new NamePart.
+                 * @memberof google.protobuf.UninterpretedOption
+                 * @classdesc Represents a NamePart.
+                 * @constructor
+                 * @param {google.protobuf.UninterpretedOption.INamePart=} [properties] Properties to set
+                 */
+                function NamePart(properties) {
+                    if (properties)
+                        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null)
+                                this[keys[i]] = properties[keys[i]];
+                }
+
+                /**
+                 * NamePart namePart.
+                 * @member {string}namePart
+                 * @memberof google.protobuf.UninterpretedOption.NamePart
+                 * @instance
+                 */
+                NamePart.prototype.namePart = "";
+
+                /**
+                 * NamePart isExtension.
+                 * @member {boolean}isExtension
+                 * @memberof google.protobuf.UninterpretedOption.NamePart
+                 * @instance
+                 */
+                NamePart.prototype.isExtension = false;
+
+                /**
+                 * Creates a new NamePart instance using the specified properties.
+                 * @function create
+                 * @memberof google.protobuf.UninterpretedOption.NamePart
+                 * @static
+                 * @param {google.protobuf.UninterpretedOption.INamePart=} [properties] Properties to set
+                 * @returns {google.protobuf.UninterpretedOption.NamePart} NamePart instance
+                 */
+                NamePart.create = function create(properties) {
+                    return new NamePart(properties);
+                };
+
+                /**
+                 * Encodes the specified NamePart message. Does not implicitly {@link google.protobuf.UninterpretedOption.NamePart.verify|verify} messages.
+                 * @function encode
+                 * @memberof google.protobuf.UninterpretedOption.NamePart
+                 * @static
+                 * @param {google.protobuf.UninterpretedOption.INamePart} message NamePart message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                NamePart.encode = function encode(message, writer) {
+                    if (!writer)
+                        writer = $Writer.create();
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.namePart);
+                    writer.uint32(/* id 2, wireType 0 =*/16).bool(message.isExtension);
+                    return writer;
+                };
+
+                /**
+                 * Encodes the specified NamePart message, length delimited. Does not implicitly {@link google.protobuf.UninterpretedOption.NamePart.verify|verify} messages.
+                 * @function encodeDelimited
+                 * @memberof google.protobuf.UninterpretedOption.NamePart
+                 * @static
+                 * @param {google.protobuf.UninterpretedOption.INamePart} message NamePart message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                NamePart.encodeDelimited = function encodeDelimited(message, writer) {
+                    return this.encode(message, writer).ldelim();
+                };
+
+                /**
+                 * Decodes a NamePart message from the specified reader or buffer.
+                 * @function decode
+                 * @memberof google.protobuf.UninterpretedOption.NamePart
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @param {number} [length] Message length if known beforehand
+                 * @returns {google.protobuf.UninterpretedOption.NamePart} NamePart
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                NamePart.decode = function decode(reader, length) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader.create(reader);
+                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.UninterpretedOption.NamePart();
+                    while (reader.pos < end) {
+                        var tag = reader.uint32();
+                        switch (tag >>> 3) {
+                        case 1:
+                            message.namePart = reader.string();
+                            break;
+                        case 2:
+                            message.isExtension = reader.bool();
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                        }
+                    }
+                    if (!message.hasOwnProperty("namePart"))
+                        throw $util.ProtocolError("missing required 'namePart'", { instance: message });
+                    if (!message.hasOwnProperty("isExtension"))
+                        throw $util.ProtocolError("missing required 'isExtension'", { instance: message });
+                    return message;
+                };
+
+                /**
+                 * Decodes a NamePart message from the specified reader or buffer, length delimited.
+                 * @function decodeDelimited
+                 * @memberof google.protobuf.UninterpretedOption.NamePart
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @returns {google.protobuf.UninterpretedOption.NamePart} NamePart
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                NamePart.decodeDelimited = function decodeDelimited(reader) {
+                    if (!(reader instanceof $Reader))
+                        reader = new $Reader(reader);
+                    return this.decode(reader, reader.uint32());
+                };
+
+                /**
+                 * Verifies a NamePart message.
+                 * @function verify
+                 * @memberof google.protobuf.UninterpretedOption.NamePart
+                 * @static
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                 */
+                NamePart.verify = function verify(message) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    if (!$util.isString(message.namePart))
+                        return "namePart: string expected";
+                    if (typeof message.isExtension !== "boolean")
+                        return "isExtension: boolean expected";
+                    return null;
+                };
+
+                /**
+                 * Creates a NamePart message from a plain object. Also converts values to their respective internal types.
+                 * @function fromObject
+                 * @memberof google.protobuf.UninterpretedOption.NamePart
+                 * @static
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {google.protobuf.UninterpretedOption.NamePart} NamePart
+                 */
+                NamePart.fromObject = function fromObject(object) {
+                    if (object instanceof $root.google.protobuf.UninterpretedOption.NamePart)
+                        return object;
+                    var message = new $root.google.protobuf.UninterpretedOption.NamePart();
+                    if (object.namePart != null)
+                        message.namePart = String(object.namePart);
+                    if (object.isExtension != null)
+                        message.isExtension = Boolean(object.isExtension);
+                    return message;
+                };
+
+                /**
+                 * Creates a plain object from a NamePart message. Also converts values to other types if specified.
+                 * @function toObject
+                 * @memberof google.protobuf.UninterpretedOption.NamePart
+                 * @static
+                 * @param {google.protobuf.UninterpretedOption.NamePart} message NamePart
+                 * @param {$protobuf.IConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                NamePart.toObject = function toObject(message, options) {
+                    if (!options)
+                        options = {};
+                    var object = {};
+                    if (options.defaults) {
+                        object.namePart = "";
+                        object.isExtension = false;
+                    }
+                    if (message.namePart != null && message.hasOwnProperty("namePart"))
+                        object.namePart = message.namePart;
+                    if (message.isExtension != null && message.hasOwnProperty("isExtension"))
+                        object.isExtension = message.isExtension;
+                    return object;
+                };
+
+                /**
+                 * Converts this NamePart to JSON.
+                 * @function toJSON
+                 * @memberof google.protobuf.UninterpretedOption.NamePart
+                 * @instance
+                 * @returns {Object.<string,*>} JSON object
+                 */
+                NamePart.prototype.toJSON = function toJSON() {
+                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                };
+
+                return NamePart;
+            })();
+
+            return UninterpretedOption;
+        })();
+
+        protobuf.SourceCodeInfo = (function() {
+
+            /**
+             * Properties of a SourceCodeInfo.
+             * @memberof google.protobuf
+             * @interface ISourceCodeInfo
+             * @property {Array.<google.protobuf.SourceCodeInfo.ILocation>} [location] SourceCodeInfo location
+             */
+
+            /**
+             * Constructs a new SourceCodeInfo.
+             * @memberof google.protobuf
+             * @classdesc Represents a SourceCodeInfo.
+             * @constructor
+             * @param {google.protobuf.ISourceCodeInfo=} [properties] Properties to set
+             */
+            function SourceCodeInfo(properties) {
+                this.location = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * SourceCodeInfo location.
+             * @member {Array.<google.protobuf.SourceCodeInfo.ILocation>}location
+             * @memberof google.protobuf.SourceCodeInfo
+             * @instance
+             */
+            SourceCodeInfo.prototype.location = $util.emptyArray;
+
+            /**
+             * Creates a new SourceCodeInfo instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.SourceCodeInfo
+             * @static
+             * @param {google.protobuf.ISourceCodeInfo=} [properties] Properties to set
+             * @returns {google.protobuf.SourceCodeInfo} SourceCodeInfo instance
+             */
+            SourceCodeInfo.create = function create(properties) {
+                return new SourceCodeInfo(properties);
+            };
+
+            /**
+             * Encodes the specified SourceCodeInfo message. Does not implicitly {@link google.protobuf.SourceCodeInfo.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.SourceCodeInfo
+             * @static
+             * @param {google.protobuf.ISourceCodeInfo} message SourceCodeInfo message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            SourceCodeInfo.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.location != null && message.location.length)
+                    for (var i = 0; i < message.location.length; ++i)
+                        $root.google.protobuf.SourceCodeInfo.Location.encode(message.location[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified SourceCodeInfo message, length delimited. Does not implicitly {@link google.protobuf.SourceCodeInfo.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.SourceCodeInfo
+             * @static
+             * @param {google.protobuf.ISourceCodeInfo} message SourceCodeInfo message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            SourceCodeInfo.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a SourceCodeInfo message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.SourceCodeInfo
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.SourceCodeInfo} SourceCodeInfo
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            SourceCodeInfo.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.SourceCodeInfo();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        if (!(message.location && message.location.length))
+                            message.location = [];
+                        message.location.push($root.google.protobuf.SourceCodeInfo.Location.decode(reader, reader.uint32()));
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a SourceCodeInfo message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.SourceCodeInfo
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.SourceCodeInfo} SourceCodeInfo
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            SourceCodeInfo.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a SourceCodeInfo message.
+             * @function verify
+             * @memberof google.protobuf.SourceCodeInfo
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            SourceCodeInfo.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.location != null && message.hasOwnProperty("location")) {
+                    if (!Array.isArray(message.location))
+                        return "location: array expected";
+                    for (var i = 0; i < message.location.length; ++i) {
+                        var error = $root.google.protobuf.SourceCodeInfo.Location.verify(message.location[i]);
+                        if (error)
+                            return "location." + error;
+                    }
+                }
+                return null;
+            };
+
+            /**
+             * Creates a SourceCodeInfo message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.SourceCodeInfo
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.SourceCodeInfo} SourceCodeInfo
+             */
+            SourceCodeInfo.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.SourceCodeInfo)
+                    return object;
+                var message = new $root.google.protobuf.SourceCodeInfo();
+                if (object.location) {
+                    if (!Array.isArray(object.location))
+                        throw TypeError(".google.protobuf.SourceCodeInfo.location: array expected");
+                    message.location = [];
+                    for (var i = 0; i < object.location.length; ++i) {
+                        if (typeof object.location[i] !== "object")
+                            throw TypeError(".google.protobuf.SourceCodeInfo.location: object expected");
+                        message.location[i] = $root.google.protobuf.SourceCodeInfo.Location.fromObject(object.location[i]);
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a SourceCodeInfo message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.SourceCodeInfo
+             * @static
+             * @param {google.protobuf.SourceCodeInfo} message SourceCodeInfo
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            SourceCodeInfo.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.location = [];
+                if (message.location && message.location.length) {
+                    object.location = [];
+                    for (var j = 0; j < message.location.length; ++j)
+                        object.location[j] = $root.google.protobuf.SourceCodeInfo.Location.toObject(message.location[j], options);
+                }
+                return object;
+            };
+
+            /**
+             * Converts this SourceCodeInfo to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.SourceCodeInfo
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            SourceCodeInfo.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            SourceCodeInfo.Location = (function() {
+
+                /**
+                 * Properties of a Location.
+                 * @memberof google.protobuf.SourceCodeInfo
+                 * @interface ILocation
+                 * @property {Array.<number>} [path] Location path
+                 * @property {Array.<number>} [span] Location span
+                 * @property {string} [leadingComments] Location leadingComments
+                 * @property {string} [trailingComments] Location trailingComments
+                 * @property {Array.<string>} [leadingDetachedComments] Location leadingDetachedComments
+                 */
+
+                /**
+                 * Constructs a new Location.
+                 * @memberof google.protobuf.SourceCodeInfo
+                 * @classdesc Represents a Location.
+                 * @constructor
+                 * @param {google.protobuf.SourceCodeInfo.ILocation=} [properties] Properties to set
+                 */
+                function Location(properties) {
+                    this.path = [];
+                    this.span = [];
+                    this.leadingDetachedComments = [];
+                    if (properties)
+                        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null)
+                                this[keys[i]] = properties[keys[i]];
+                }
+
+                /**
+                 * Location path.
+                 * @member {Array.<number>}path
+                 * @memberof google.protobuf.SourceCodeInfo.Location
+                 * @instance
+                 */
+                Location.prototype.path = $util.emptyArray;
+
+                /**
+                 * Location span.
+                 * @member {Array.<number>}span
+                 * @memberof google.protobuf.SourceCodeInfo.Location
+                 * @instance
+                 */
+                Location.prototype.span = $util.emptyArray;
+
+                /**
+                 * Location leadingComments.
+                 * @member {string}leadingComments
+                 * @memberof google.protobuf.SourceCodeInfo.Location
+                 * @instance
+                 */
+                Location.prototype.leadingComments = "";
+
+                /**
+                 * Location trailingComments.
+                 * @member {string}trailingComments
+                 * @memberof google.protobuf.SourceCodeInfo.Location
+                 * @instance
+                 */
+                Location.prototype.trailingComments = "";
+
+                /**
+                 * Location leadingDetachedComments.
+                 * @member {Array.<string>}leadingDetachedComments
+                 * @memberof google.protobuf.SourceCodeInfo.Location
+                 * @instance
+                 */
+                Location.prototype.leadingDetachedComments = $util.emptyArray;
+
+                /**
+                 * Creates a new Location instance using the specified properties.
+                 * @function create
+                 * @memberof google.protobuf.SourceCodeInfo.Location
+                 * @static
+                 * @param {google.protobuf.SourceCodeInfo.ILocation=} [properties] Properties to set
+                 * @returns {google.protobuf.SourceCodeInfo.Location} Location instance
+                 */
+                Location.create = function create(properties) {
+                    return new Location(properties);
+                };
+
+                /**
+                 * Encodes the specified Location message. Does not implicitly {@link google.protobuf.SourceCodeInfo.Location.verify|verify} messages.
+                 * @function encode
+                 * @memberof google.protobuf.SourceCodeInfo.Location
+                 * @static
+                 * @param {google.protobuf.SourceCodeInfo.ILocation} message Location message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                Location.encode = function encode(message, writer) {
+                    if (!writer)
+                        writer = $Writer.create();
+                    if (message.path != null && message.path.length) {
+                        writer.uint32(/* id 1, wireType 2 =*/10).fork();
+                        for (var i = 0; i < message.path.length; ++i)
+                            writer.int32(message.path[i]);
+                        writer.ldelim();
+                    }
+                    if (message.span != null && message.span.length) {
+                        writer.uint32(/* id 2, wireType 2 =*/18).fork();
+                        for (var i = 0; i < message.span.length; ++i)
+                            writer.int32(message.span[i]);
+                        writer.ldelim();
+                    }
+                    if (message.leadingComments != null && message.hasOwnProperty("leadingComments"))
+                        writer.uint32(/* id 3, wireType 2 =*/26).string(message.leadingComments);
+                    if (message.trailingComments != null && message.hasOwnProperty("trailingComments"))
+                        writer.uint32(/* id 4, wireType 2 =*/34).string(message.trailingComments);
+                    if (message.leadingDetachedComments != null && message.leadingDetachedComments.length)
+                        for (var i = 0; i < message.leadingDetachedComments.length; ++i)
+                            writer.uint32(/* id 6, wireType 2 =*/50).string(message.leadingDetachedComments[i]);
+                    return writer;
+                };
+
+                /**
+                 * Encodes the specified Location message, length delimited. Does not implicitly {@link google.protobuf.SourceCodeInfo.Location.verify|verify} messages.
+                 * @function encodeDelimited
+                 * @memberof google.protobuf.SourceCodeInfo.Location
+                 * @static
+                 * @param {google.protobuf.SourceCodeInfo.ILocation} message Location message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                Location.encodeDelimited = function encodeDelimited(message, writer) {
+                    return this.encode(message, writer).ldelim();
+                };
+
+                /**
+                 * Decodes a Location message from the specified reader or buffer.
+                 * @function decode
+                 * @memberof google.protobuf.SourceCodeInfo.Location
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @param {number} [length] Message length if known beforehand
+                 * @returns {google.protobuf.SourceCodeInfo.Location} Location
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                Location.decode = function decode(reader, length) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader.create(reader);
+                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.SourceCodeInfo.Location();
+                    while (reader.pos < end) {
+                        var tag = reader.uint32();
+                        switch (tag >>> 3) {
+                        case 1:
+                            if (!(message.path && message.path.length))
+                                message.path = [];
+                            if ((tag & 7) === 2) {
+                                var end2 = reader.uint32() + reader.pos;
+                                while (reader.pos < end2)
+                                    message.path.push(reader.int32());
+                            } else
+                                message.path.push(reader.int32());
+                            break;
+                        case 2:
+                            if (!(message.span && message.span.length))
+                                message.span = [];
+                            if ((tag & 7) === 2) {
+                                var end2 = reader.uint32() + reader.pos;
+                                while (reader.pos < end2)
+                                    message.span.push(reader.int32());
+                            } else
+                                message.span.push(reader.int32());
+                            break;
+                        case 3:
+                            message.leadingComments = reader.string();
+                            break;
+                        case 4:
+                            message.trailingComments = reader.string();
+                            break;
+                        case 6:
+                            if (!(message.leadingDetachedComments && message.leadingDetachedComments.length))
+                                message.leadingDetachedComments = [];
+                            message.leadingDetachedComments.push(reader.string());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                        }
+                    }
+                    return message;
+                };
+
+                /**
+                 * Decodes a Location message from the specified reader or buffer, length delimited.
+                 * @function decodeDelimited
+                 * @memberof google.protobuf.SourceCodeInfo.Location
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @returns {google.protobuf.SourceCodeInfo.Location} Location
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                Location.decodeDelimited = function decodeDelimited(reader) {
+                    if (!(reader instanceof $Reader))
+                        reader = new $Reader(reader);
+                    return this.decode(reader, reader.uint32());
+                };
+
+                /**
+                 * Verifies a Location message.
+                 * @function verify
+                 * @memberof google.protobuf.SourceCodeInfo.Location
+                 * @static
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                 */
+                Location.verify = function verify(message) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    if (message.path != null && message.hasOwnProperty("path")) {
+                        if (!Array.isArray(message.path))
+                            return "path: array expected";
+                        for (var i = 0; i < message.path.length; ++i)
+                            if (!$util.isInteger(message.path[i]))
+                                return "path: integer[] expected";
+                    }
+                    if (message.span != null && message.hasOwnProperty("span")) {
+                        if (!Array.isArray(message.span))
+                            return "span: array expected";
+                        for (var i = 0; i < message.span.length; ++i)
+                            if (!$util.isInteger(message.span[i]))
+                                return "span: integer[] expected";
+                    }
+                    if (message.leadingComments != null && message.hasOwnProperty("leadingComments"))
+                        if (!$util.isString(message.leadingComments))
+                            return "leadingComments: string expected";
+                    if (message.trailingComments != null && message.hasOwnProperty("trailingComments"))
+                        if (!$util.isString(message.trailingComments))
+                            return "trailingComments: string expected";
+                    if (message.leadingDetachedComments != null && message.hasOwnProperty("leadingDetachedComments")) {
+                        if (!Array.isArray(message.leadingDetachedComments))
+                            return "leadingDetachedComments: array expected";
+                        for (var i = 0; i < message.leadingDetachedComments.length; ++i)
+                            if (!$util.isString(message.leadingDetachedComments[i]))
+                                return "leadingDetachedComments: string[] expected";
+                    }
+                    return null;
+                };
+
+                /**
+                 * Creates a Location message from a plain object. Also converts values to their respective internal types.
+                 * @function fromObject
+                 * @memberof google.protobuf.SourceCodeInfo.Location
+                 * @static
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {google.protobuf.SourceCodeInfo.Location} Location
+                 */
+                Location.fromObject = function fromObject(object) {
+                    if (object instanceof $root.google.protobuf.SourceCodeInfo.Location)
+                        return object;
+                    var message = new $root.google.protobuf.SourceCodeInfo.Location();
+                    if (object.path) {
+                        if (!Array.isArray(object.path))
+                            throw TypeError(".google.protobuf.SourceCodeInfo.Location.path: array expected");
+                        message.path = [];
+                        for (var i = 0; i < object.path.length; ++i)
+                            message.path[i] = object.path[i] | 0;
+                    }
+                    if (object.span) {
+                        if (!Array.isArray(object.span))
+                            throw TypeError(".google.protobuf.SourceCodeInfo.Location.span: array expected");
+                        message.span = [];
+                        for (var i = 0; i < object.span.length; ++i)
+                            message.span[i] = object.span[i] | 0;
+                    }
+                    if (object.leadingComments != null)
+                        message.leadingComments = String(object.leadingComments);
+                    if (object.trailingComments != null)
+                        message.trailingComments = String(object.trailingComments);
+                    if (object.leadingDetachedComments) {
+                        if (!Array.isArray(object.leadingDetachedComments))
+                            throw TypeError(".google.protobuf.SourceCodeInfo.Location.leadingDetachedComments: array expected");
+                        message.leadingDetachedComments = [];
+                        for (var i = 0; i < object.leadingDetachedComments.length; ++i)
+                            message.leadingDetachedComments[i] = String(object.leadingDetachedComments[i]);
+                    }
+                    return message;
+                };
+
+                /**
+                 * Creates a plain object from a Location message. Also converts values to other types if specified.
+                 * @function toObject
+                 * @memberof google.protobuf.SourceCodeInfo.Location
+                 * @static
+                 * @param {google.protobuf.SourceCodeInfo.Location} message Location
+                 * @param {$protobuf.IConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                Location.toObject = function toObject(message, options) {
+                    if (!options)
+                        options = {};
+                    var object = {};
+                    if (options.arrays || options.defaults) {
+                        object.path = [];
+                        object.span = [];
+                        object.leadingDetachedComments = [];
+                    }
+                    if (options.defaults) {
+                        object.leadingComments = "";
+                        object.trailingComments = "";
+                    }
+                    if (message.path && message.path.length) {
+                        object.path = [];
+                        for (var j = 0; j < message.path.length; ++j)
+                            object.path[j] = message.path[j];
+                    }
+                    if (message.span && message.span.length) {
+                        object.span = [];
+                        for (var j = 0; j < message.span.length; ++j)
+                            object.span[j] = message.span[j];
+                    }
+                    if (message.leadingComments != null && message.hasOwnProperty("leadingComments"))
+                        object.leadingComments = message.leadingComments;
+                    if (message.trailingComments != null && message.hasOwnProperty("trailingComments"))
+                        object.trailingComments = message.trailingComments;
+                    if (message.leadingDetachedComments && message.leadingDetachedComments.length) {
+                        object.leadingDetachedComments = [];
+                        for (var j = 0; j < message.leadingDetachedComments.length; ++j)
+                            object.leadingDetachedComments[j] = message.leadingDetachedComments[j];
+                    }
+                    return object;
+                };
+
+                /**
+                 * Converts this Location to JSON.
+                 * @function toJSON
+                 * @memberof google.protobuf.SourceCodeInfo.Location
+                 * @instance
+                 * @returns {Object.<string,*>} JSON object
+                 */
+                Location.prototype.toJSON = function toJSON() {
+                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                };
+
+                return Location;
+            })();
+
+            return SourceCodeInfo;
+        })();
+
+        protobuf.GeneratedCodeInfo = (function() {
+
+            /**
+             * Properties of a GeneratedCodeInfo.
+             * @memberof google.protobuf
+             * @interface IGeneratedCodeInfo
+             * @property {Array.<google.protobuf.GeneratedCodeInfo.IAnnotation>} [annotation] GeneratedCodeInfo annotation
+             */
+
+            /**
+             * Constructs a new GeneratedCodeInfo.
+             * @memberof google.protobuf
+             * @classdesc Represents a GeneratedCodeInfo.
+             * @constructor
+             * @param {google.protobuf.IGeneratedCodeInfo=} [properties] Properties to set
+             */
+            function GeneratedCodeInfo(properties) {
+                this.annotation = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * GeneratedCodeInfo annotation.
+             * @member {Array.<google.protobuf.GeneratedCodeInfo.IAnnotation>}annotation
+             * @memberof google.protobuf.GeneratedCodeInfo
+             * @instance
+             */
+            GeneratedCodeInfo.prototype.annotation = $util.emptyArray;
+
+            /**
+             * Creates a new GeneratedCodeInfo instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.GeneratedCodeInfo
+             * @static
+             * @param {google.protobuf.IGeneratedCodeInfo=} [properties] Properties to set
+             * @returns {google.protobuf.GeneratedCodeInfo} GeneratedCodeInfo instance
+             */
+            GeneratedCodeInfo.create = function create(properties) {
+                return new GeneratedCodeInfo(properties);
+            };
+
+            /**
+             * Encodes the specified GeneratedCodeInfo message. Does not implicitly {@link google.protobuf.GeneratedCodeInfo.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.GeneratedCodeInfo
+             * @static
+             * @param {google.protobuf.IGeneratedCodeInfo} message GeneratedCodeInfo message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            GeneratedCodeInfo.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.annotation != null && message.annotation.length)
+                    for (var i = 0; i < message.annotation.length; ++i)
+                        $root.google.protobuf.GeneratedCodeInfo.Annotation.encode(message.annotation[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified GeneratedCodeInfo message, length delimited. Does not implicitly {@link google.protobuf.GeneratedCodeInfo.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.GeneratedCodeInfo
+             * @static
+             * @param {google.protobuf.IGeneratedCodeInfo} message GeneratedCodeInfo message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            GeneratedCodeInfo.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a GeneratedCodeInfo message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.GeneratedCodeInfo
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.GeneratedCodeInfo} GeneratedCodeInfo
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            GeneratedCodeInfo.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.GeneratedCodeInfo();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        if (!(message.annotation && message.annotation.length))
+                            message.annotation = [];
+                        message.annotation.push($root.google.protobuf.GeneratedCodeInfo.Annotation.decode(reader, reader.uint32()));
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a GeneratedCodeInfo message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.GeneratedCodeInfo
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.GeneratedCodeInfo} GeneratedCodeInfo
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            GeneratedCodeInfo.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a GeneratedCodeInfo message.
+             * @function verify
+             * @memberof google.protobuf.GeneratedCodeInfo
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            GeneratedCodeInfo.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.annotation != null && message.hasOwnProperty("annotation")) {
+                    if (!Array.isArray(message.annotation))
+                        return "annotation: array expected";
+                    for (var i = 0; i < message.annotation.length; ++i) {
+                        var error = $root.google.protobuf.GeneratedCodeInfo.Annotation.verify(message.annotation[i]);
+                        if (error)
+                            return "annotation." + error;
+                    }
+                }
+                return null;
+            };
+
+            /**
+             * Creates a GeneratedCodeInfo message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.GeneratedCodeInfo
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.GeneratedCodeInfo} GeneratedCodeInfo
+             */
+            GeneratedCodeInfo.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.GeneratedCodeInfo)
+                    return object;
+                var message = new $root.google.protobuf.GeneratedCodeInfo();
+                if (object.annotation) {
+                    if (!Array.isArray(object.annotation))
+                        throw TypeError(".google.protobuf.GeneratedCodeInfo.annotation: array expected");
+                    message.annotation = [];
+                    for (var i = 0; i < object.annotation.length; ++i) {
+                        if (typeof object.annotation[i] !== "object")
+                            throw TypeError(".google.protobuf.GeneratedCodeInfo.annotation: object expected");
+                        message.annotation[i] = $root.google.protobuf.GeneratedCodeInfo.Annotation.fromObject(object.annotation[i]);
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a GeneratedCodeInfo message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.GeneratedCodeInfo
+             * @static
+             * @param {google.protobuf.GeneratedCodeInfo} message GeneratedCodeInfo
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            GeneratedCodeInfo.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.annotation = [];
+                if (message.annotation && message.annotation.length) {
+                    object.annotation = [];
+                    for (var j = 0; j < message.annotation.length; ++j)
+                        object.annotation[j] = $root.google.protobuf.GeneratedCodeInfo.Annotation.toObject(message.annotation[j], options);
+                }
+                return object;
+            };
+
+            /**
+             * Converts this GeneratedCodeInfo to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.GeneratedCodeInfo
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            GeneratedCodeInfo.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            GeneratedCodeInfo.Annotation = (function() {
+
+                /**
+                 * Properties of an Annotation.
+                 * @memberof google.protobuf.GeneratedCodeInfo
+                 * @interface IAnnotation
+                 * @property {Array.<number>} [path] Annotation path
+                 * @property {string} [sourceFile] Annotation sourceFile
+                 * @property {number} [begin] Annotation begin
+                 * @property {number} [end] Annotation end
+                 */
+
+                /**
+                 * Constructs a new Annotation.
+                 * @memberof google.protobuf.GeneratedCodeInfo
+                 * @classdesc Represents an Annotation.
+                 * @constructor
+                 * @param {google.protobuf.GeneratedCodeInfo.IAnnotation=} [properties] Properties to set
+                 */
+                function Annotation(properties) {
+                    this.path = [];
+                    if (properties)
+                        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null)
+                                this[keys[i]] = properties[keys[i]];
+                }
+
+                /**
+                 * Annotation path.
+                 * @member {Array.<number>}path
+                 * @memberof google.protobuf.GeneratedCodeInfo.Annotation
+                 * @instance
+                 */
+                Annotation.prototype.path = $util.emptyArray;
+
+                /**
+                 * Annotation sourceFile.
+                 * @member {string}sourceFile
+                 * @memberof google.protobuf.GeneratedCodeInfo.Annotation
+                 * @instance
+                 */
+                Annotation.prototype.sourceFile = "";
+
+                /**
+                 * Annotation begin.
+                 * @member {number}begin
+                 * @memberof google.protobuf.GeneratedCodeInfo.Annotation
+                 * @instance
+                 */
+                Annotation.prototype.begin = 0;
+
+                /**
+                 * Annotation end.
+                 * @member {number}end
+                 * @memberof google.protobuf.GeneratedCodeInfo.Annotation
+                 * @instance
+                 */
+                Annotation.prototype.end = 0;
+
+                /**
+                 * Creates a new Annotation instance using the specified properties.
+                 * @function create
+                 * @memberof google.protobuf.GeneratedCodeInfo.Annotation
+                 * @static
+                 * @param {google.protobuf.GeneratedCodeInfo.IAnnotation=} [properties] Properties to set
+                 * @returns {google.protobuf.GeneratedCodeInfo.Annotation} Annotation instance
+                 */
+                Annotation.create = function create(properties) {
+                    return new Annotation(properties);
+                };
+
+                /**
+                 * Encodes the specified Annotation message. Does not implicitly {@link google.protobuf.GeneratedCodeInfo.Annotation.verify|verify} messages.
+                 * @function encode
+                 * @memberof google.protobuf.GeneratedCodeInfo.Annotation
+                 * @static
+                 * @param {google.protobuf.GeneratedCodeInfo.IAnnotation} message Annotation message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                Annotation.encode = function encode(message, writer) {
+                    if (!writer)
+                        writer = $Writer.create();
+                    if (message.path != null && message.path.length) {
+                        writer.uint32(/* id 1, wireType 2 =*/10).fork();
+                        for (var i = 0; i < message.path.length; ++i)
+                            writer.int32(message.path[i]);
+                        writer.ldelim();
+                    }
+                    if (message.sourceFile != null && message.hasOwnProperty("sourceFile"))
+                        writer.uint32(/* id 2, wireType 2 =*/18).string(message.sourceFile);
+                    if (message.begin != null && message.hasOwnProperty("begin"))
+                        writer.uint32(/* id 3, wireType 0 =*/24).int32(message.begin);
+                    if (message.end != null && message.hasOwnProperty("end"))
+                        writer.uint32(/* id 4, wireType 0 =*/32).int32(message.end);
+                    return writer;
+                };
+
+                /**
+                 * Encodes the specified Annotation message, length delimited. Does not implicitly {@link google.protobuf.GeneratedCodeInfo.Annotation.verify|verify} messages.
+                 * @function encodeDelimited
+                 * @memberof google.protobuf.GeneratedCodeInfo.Annotation
+                 * @static
+                 * @param {google.protobuf.GeneratedCodeInfo.IAnnotation} message Annotation message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                Annotation.encodeDelimited = function encodeDelimited(message, writer) {
+                    return this.encode(message, writer).ldelim();
+                };
+
+                /**
+                 * Decodes an Annotation message from the specified reader or buffer.
+                 * @function decode
+                 * @memberof google.protobuf.GeneratedCodeInfo.Annotation
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @param {number} [length] Message length if known beforehand
+                 * @returns {google.protobuf.GeneratedCodeInfo.Annotation} Annotation
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                Annotation.decode = function decode(reader, length) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader.create(reader);
+                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.GeneratedCodeInfo.Annotation();
+                    while (reader.pos < end) {
+                        var tag = reader.uint32();
+                        switch (tag >>> 3) {
+                        case 1:
+                            if (!(message.path && message.path.length))
+                                message.path = [];
+                            if ((tag & 7) === 2) {
+                                var end2 = reader.uint32() + reader.pos;
+                                while (reader.pos < end2)
+                                    message.path.push(reader.int32());
+                            } else
+                                message.path.push(reader.int32());
+                            break;
+                        case 2:
+                            message.sourceFile = reader.string();
+                            break;
+                        case 3:
+                            message.begin = reader.int32();
+                            break;
+                        case 4:
+                            message.end = reader.int32();
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                        }
+                    }
+                    return message;
+                };
+
+                /**
+                 * Decodes an Annotation message from the specified reader or buffer, length delimited.
+                 * @function decodeDelimited
+                 * @memberof google.protobuf.GeneratedCodeInfo.Annotation
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @returns {google.protobuf.GeneratedCodeInfo.Annotation} Annotation
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                Annotation.decodeDelimited = function decodeDelimited(reader) {
+                    if (!(reader instanceof $Reader))
+                        reader = new $Reader(reader);
+                    return this.decode(reader, reader.uint32());
+                };
+
+                /**
+                 * Verifies an Annotation message.
+                 * @function verify
+                 * @memberof google.protobuf.GeneratedCodeInfo.Annotation
+                 * @static
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                 */
+                Annotation.verify = function verify(message) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    if (message.path != null && message.hasOwnProperty("path")) {
+                        if (!Array.isArray(message.path))
+                            return "path: array expected";
+                        for (var i = 0; i < message.path.length; ++i)
+                            if (!$util.isInteger(message.path[i]))
+                                return "path: integer[] expected";
+                    }
+                    if (message.sourceFile != null && message.hasOwnProperty("sourceFile"))
+                        if (!$util.isString(message.sourceFile))
+                            return "sourceFile: string expected";
+                    if (message.begin != null && message.hasOwnProperty("begin"))
+                        if (!$util.isInteger(message.begin))
+                            return "begin: integer expected";
+                    if (message.end != null && message.hasOwnProperty("end"))
+                        if (!$util.isInteger(message.end))
+                            return "end: integer expected";
+                    return null;
+                };
+
+                /**
+                 * Creates an Annotation message from a plain object. Also converts values to their respective internal types.
+                 * @function fromObject
+                 * @memberof google.protobuf.GeneratedCodeInfo.Annotation
+                 * @static
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {google.protobuf.GeneratedCodeInfo.Annotation} Annotation
+                 */
+                Annotation.fromObject = function fromObject(object) {
+                    if (object instanceof $root.google.protobuf.GeneratedCodeInfo.Annotation)
+                        return object;
+                    var message = new $root.google.protobuf.GeneratedCodeInfo.Annotation();
+                    if (object.path) {
+                        if (!Array.isArray(object.path))
+                            throw TypeError(".google.protobuf.GeneratedCodeInfo.Annotation.path: array expected");
+                        message.path = [];
+                        for (var i = 0; i < object.path.length; ++i)
+                            message.path[i] = object.path[i] | 0;
+                    }
+                    if (object.sourceFile != null)
+                        message.sourceFile = String(object.sourceFile);
+                    if (object.begin != null)
+                        message.begin = object.begin | 0;
+                    if (object.end != null)
+                        message.end = object.end | 0;
+                    return message;
+                };
+
+                /**
+                 * Creates a plain object from an Annotation message. Also converts values to other types if specified.
+                 * @function toObject
+                 * @memberof google.protobuf.GeneratedCodeInfo.Annotation
+                 * @static
+                 * @param {google.protobuf.GeneratedCodeInfo.Annotation} message Annotation
+                 * @param {$protobuf.IConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                Annotation.toObject = function toObject(message, options) {
+                    if (!options)
+                        options = {};
+                    var object = {};
+                    if (options.arrays || options.defaults)
+                        object.path = [];
+                    if (options.defaults) {
+                        object.sourceFile = "";
+                        object.begin = 0;
+                        object.end = 0;
+                    }
+                    if (message.path && message.path.length) {
+                        object.path = [];
+                        for (var j = 0; j < message.path.length; ++j)
+                            object.path[j] = message.path[j];
+                    }
+                    if (message.sourceFile != null && message.hasOwnProperty("sourceFile"))
+                        object.sourceFile = message.sourceFile;
+                    if (message.begin != null && message.hasOwnProperty("begin"))
+                        object.begin = message.begin;
+                    if (message.end != null && message.hasOwnProperty("end"))
+                        object.end = message.end;
+                    return object;
+                };
+
+                /**
+                 * Converts this Annotation to JSON.
+                 * @function toJSON
+                 * @memberof google.protobuf.GeneratedCodeInfo.Annotation
+                 * @instance
+                 * @returns {Object.<string,*>} JSON object
+                 */
+                Annotation.prototype.toJSON = function toJSON() {
+                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                };
+
+                return Annotation;
+            })();
+
+            return GeneratedCodeInfo;
+        })();
+
+        protobuf.Duration = (function() {
+
+            /**
+             * Properties of a Duration.
+             * @memberof google.protobuf
+             * @interface IDuration
+             * @property {number|Long} [seconds] Duration seconds
+             * @property {number} [nanos] Duration nanos
+             */
+
+            /**
+             * Constructs a new Duration.
+             * @memberof google.protobuf
+             * @classdesc Represents a Duration.
+             * @constructor
+             * @param {google.protobuf.IDuration=} [properties] Properties to set
+             */
+            function Duration(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * Duration seconds.
+             * @member {number|Long}seconds
+             * @memberof google.protobuf.Duration
+             * @instance
+             */
+            Duration.prototype.seconds = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+
+            /**
+             * Duration nanos.
+             * @member {number}nanos
+             * @memberof google.protobuf.Duration
+             * @instance
+             */
+            Duration.prototype.nanos = 0;
+
+            /**
+             * Creates a new Duration instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.Duration
+             * @static
+             * @param {google.protobuf.IDuration=} [properties] Properties to set
+             * @returns {google.protobuf.Duration} Duration instance
+             */
+            Duration.create = function create(properties) {
+                return new Duration(properties);
+            };
+
+            /**
+             * Encodes the specified Duration message. Does not implicitly {@link google.protobuf.Duration.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.Duration
+             * @static
+             * @param {google.protobuf.IDuration} message Duration message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            Duration.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.seconds != null && message.hasOwnProperty("seconds"))
+                    writer.uint32(/* id 1, wireType 0 =*/8).int64(message.seconds);
+                if (message.nanos != null && message.hasOwnProperty("nanos"))
+                    writer.uint32(/* id 2, wireType 0 =*/16).int32(message.nanos);
+                return writer;
+            };
+
+            /**
+             * Encodes the specified Duration message, length delimited. Does not implicitly {@link google.protobuf.Duration.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.Duration
+             * @static
+             * @param {google.protobuf.IDuration} message Duration message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            Duration.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a Duration message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.Duration
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.Duration} Duration
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            Duration.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.Duration();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.seconds = reader.int64();
+                        break;
+                    case 2:
+                        message.nanos = reader.int32();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a Duration message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.Duration
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.Duration} Duration
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            Duration.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a Duration message.
+             * @function verify
+             * @memberof google.protobuf.Duration
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            Duration.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.seconds != null && message.hasOwnProperty("seconds"))
+                    if (!$util.isInteger(message.seconds) && !(message.seconds && $util.isInteger(message.seconds.low) && $util.isInteger(message.seconds.high)))
+                        return "seconds: integer|Long expected";
+                if (message.nanos != null && message.hasOwnProperty("nanos"))
+                    if (!$util.isInteger(message.nanos))
+                        return "nanos: integer expected";
+                return null;
+            };
+
+            /**
+             * Creates a Duration message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.Duration
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.Duration} Duration
+             */
+            Duration.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.Duration)
+                    return object;
+                var message = new $root.google.protobuf.Duration();
+                if (object.seconds != null)
+                    if ($util.Long)
+                        (message.seconds = $util.Long.fromValue(object.seconds)).unsigned = false;
+                    else if (typeof object.seconds === "string")
+                        message.seconds = parseInt(object.seconds, 10);
+                    else if (typeof object.seconds === "number")
+                        message.seconds = object.seconds;
+                    else if (typeof object.seconds === "object")
+                        message.seconds = new $util.LongBits(object.seconds.low >>> 0, object.seconds.high >>> 0).toNumber();
+                if (object.nanos != null)
+                    message.nanos = object.nanos | 0;
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a Duration message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.Duration
+             * @static
+             * @param {google.protobuf.Duration} message Duration
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            Duration.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    if ($util.Long) {
+                        var long = new $util.Long(0, 0, false);
+                        object.seconds = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                    } else
+                        object.seconds = options.longs === String ? "0" : 0;
+                    object.nanos = 0;
+                }
+                if (message.seconds != null && message.hasOwnProperty("seconds"))
+                    if (typeof message.seconds === "number")
+                        object.seconds = options.longs === String ? String(message.seconds) : message.seconds;
+                    else
+                        object.seconds = options.longs === String ? $util.Long.prototype.toString.call(message.seconds) : options.longs === Number ? new $util.LongBits(message.seconds.low >>> 0, message.seconds.high >>> 0).toNumber() : message.seconds;
+                if (message.nanos != null && message.hasOwnProperty("nanos"))
+                    object.nanos = message.nanos;
+                return object;
+            };
+
+            /**
+             * Converts this Duration to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.Duration
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            Duration.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return Duration;
+        })();
+
+        protobuf.Timestamp = (function() {
+
+            /**
+             * Properties of a Timestamp.
+             * @memberof google.protobuf
+             * @interface ITimestamp
+             * @property {number|Long} [seconds] Timestamp seconds
+             * @property {number} [nanos] Timestamp nanos
+             */
+
+            /**
+             * Constructs a new Timestamp.
+             * @memberof google.protobuf
+             * @classdesc Represents a Timestamp.
+             * @constructor
+             * @param {google.protobuf.ITimestamp=} [properties] Properties to set
+             */
+            function Timestamp(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * Timestamp seconds.
+             * @member {number|Long}seconds
+             * @memberof google.protobuf.Timestamp
+             * @instance
+             */
+            Timestamp.prototype.seconds = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+
+            /**
+             * Timestamp nanos.
+             * @member {number}nanos
+             * @memberof google.protobuf.Timestamp
+             * @instance
+             */
+            Timestamp.prototype.nanos = 0;
+
+            /**
+             * Creates a new Timestamp instance using the specified properties.
+             * @function create
+             * @memberof google.protobuf.Timestamp
+             * @static
+             * @param {google.protobuf.ITimestamp=} [properties] Properties to set
+             * @returns {google.protobuf.Timestamp} Timestamp instance
+             */
+            Timestamp.create = function create(properties) {
+                return new Timestamp(properties);
+            };
+
+            /**
+             * Encodes the specified Timestamp message. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
+             * @function encode
+             * @memberof google.protobuf.Timestamp
+             * @static
+             * @param {google.protobuf.ITimestamp} message Timestamp message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            Timestamp.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.seconds != null && message.hasOwnProperty("seconds"))
+                    writer.uint32(/* id 1, wireType 0 =*/8).int64(message.seconds);
+                if (message.nanos != null && message.hasOwnProperty("nanos"))
+                    writer.uint32(/* id 2, wireType 0 =*/16).int32(message.nanos);
+                return writer;
+            };
+
+            /**
+             * Encodes the specified Timestamp message, length delimited. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof google.protobuf.Timestamp
+             * @static
+             * @param {google.protobuf.ITimestamp} message Timestamp message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            Timestamp.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a Timestamp message from the specified reader or buffer.
+             * @function decode
+             * @memberof google.protobuf.Timestamp
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {google.protobuf.Timestamp} Timestamp
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            Timestamp.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.Timestamp();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.seconds = reader.int64();
+                        break;
+                    case 2:
+                        message.nanos = reader.int32();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a Timestamp message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof google.protobuf.Timestamp
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {google.protobuf.Timestamp} Timestamp
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            Timestamp.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a Timestamp message.
+             * @function verify
+             * @memberof google.protobuf.Timestamp
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            Timestamp.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.seconds != null && message.hasOwnProperty("seconds"))
+                    if (!$util.isInteger(message.seconds) && !(message.seconds && $util.isInteger(message.seconds.low) && $util.isInteger(message.seconds.high)))
+                        return "seconds: integer|Long expected";
+                if (message.nanos != null && message.hasOwnProperty("nanos"))
+                    if (!$util.isInteger(message.nanos))
+                        return "nanos: integer expected";
+                return null;
+            };
+
+            /**
+             * Creates a Timestamp message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof google.protobuf.Timestamp
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {google.protobuf.Timestamp} Timestamp
+             */
+            Timestamp.fromObject = function fromObject(object) {
+                if (object instanceof $root.google.protobuf.Timestamp)
+                    return object;
+                var message = new $root.google.protobuf.Timestamp();
+                if (object.seconds != null)
+                    if ($util.Long)
+                        (message.seconds = $util.Long.fromValue(object.seconds)).unsigned = false;
+                    else if (typeof object.seconds === "string")
+                        message.seconds = parseInt(object.seconds, 10);
+                    else if (typeof object.seconds === "number")
+                        message.seconds = object.seconds;
+                    else if (typeof object.seconds === "object")
+                        message.seconds = new $util.LongBits(object.seconds.low >>> 0, object.seconds.high >>> 0).toNumber();
+                if (object.nanos != null)
+                    message.nanos = object.nanos | 0;
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a Timestamp message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof google.protobuf.Timestamp
+             * @static
+             * @param {google.protobuf.Timestamp} message Timestamp
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            Timestamp.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    if ($util.Long) {
+                        var long = new $util.Long(0, 0, false);
+                        object.seconds = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                    } else
+                        object.seconds = options.longs === String ? "0" : 0;
+                    object.nanos = 0;
+                }
+                if (message.seconds != null && message.hasOwnProperty("seconds"))
+                    if (typeof message.seconds === "number")
+                        object.seconds = options.longs === String ? String(message.seconds) : message.seconds;
+                    else
+                        object.seconds = options.longs === String ? $util.Long.prototype.toString.call(message.seconds) : options.longs === Number ? new $util.LongBits(message.seconds.low >>> 0, message.seconds.high >>> 0).toNumber() : message.seconds;
+                if (message.nanos != null && message.hasOwnProperty("nanos"))
+                    object.nanos = message.nanos;
+                return object;
+            };
+
+            /**
+             * Converts this Timestamp to JSON.
+             * @function toJSON
+             * @memberof google.protobuf.Timestamp
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            Timestamp.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return Timestamp;
+        })();
+
+        return protobuf;
+    })();
+
+    return google;
+})();
+
+module.exports = $root;


### PR DESCRIPTION
Now that we have `profiler.proto` imported, add rules for, and generate JS and type definitions from the proto.