### PR TITLE
fix: remove build/ from nyc exclude

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   ],
   "nyc": {
     "exclude": [
-      "build",
       "proto"
     ]
   }


### PR DESCRIPTION
Coverage reporting regressed by #29 which added build/ to nyc.exclude
configuration.