### PR TITLE
fix: ignore build/test in test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   ],
   "nyc": {
     "exclude": [
-      "proto"
+      "proto",
+      "build/test"
     ]
   }
 }


### PR DESCRIPTION
Including tests in code coverage report seems to be inflating the overall code coverage.
I feel that this makes the code coverage report misleading, so tests should not be included in code coverage.