### PR TITLE
fix: should use '(anonymous)' as function name when no name specified

### DIFF
--- a/ts/src/profilers/profile-serializer.ts
+++ b/ts/src/profilers/profile-serializer.ts
@@ -140,7 +140,7 @@ function serialize<T extends ProfileNode>(
     }
     id = functions.length + 1;
     functionIdMap.set(keyStr, id);
-    let nameId = stringTable.getIndexOrAdd(node.name);
+    let nameId = stringTable.getIndexOrAdd(node.name || '(anonymous)');
     let f = new perftools.profiles.Function({
       id: id,
       name: nameId,

--- a/ts/src/v8-types.ts
+++ b/ts/src/v8-types.ts
@@ -26,7 +26,7 @@ export interface TimeProfile {
 
 export interface ProfileNode {
   // name is the function name.
-  name: string;
+  name?: string;
   scriptName: string;
   scriptId: number;
   lineNumber: number;

--- a/ts/test/profiles-for-tests.ts
+++ b/ts/test/profiles-for-tests.ts
@@ -299,7 +299,7 @@ export const anonymousFunctionHeapProfile: perftools.profiles.IProfile = {
   function: anonymousFunctionHeapFunctions,
   stringTable: [
     '',
-    'samples',
+    'objects',
     'count',
     'space',
     'bytes',
@@ -307,7 +307,6 @@ export const anonymousFunctionHeapProfile: perftools.profiles.IProfile = {
     'main',
   ],
   timeNanos: 0,
-  durationNanos: 10 * 1000 * 1000 * 1000,
   periodType: new perftools.profiles.ValueType({type: 3, unit: 4}),
   period: 524288
 };

--- a/ts/test/profiles-for-tests.ts
+++ b/ts/test/profiles-for-tests.ts
@@ -254,3 +254,126 @@ export const heapProfile: perftools.profiles.IProfile = {
   periodType: new perftools.profiles.ValueType({type: 3, unit: 4}),
   period: 524288
 };
+
+
+const anonymousHeapNode = {
+  scriptName: 'main',
+  scriptId: 0,
+  lineNumber: 1,
+  columnNumber: 5,
+  allocations: [{count: 1, sizeBytes: 5}],
+  children: []
+};
+
+export const v8AnonymousFunctionHeapProfile = {
+  name: '(root)',
+  scriptName: '(root)',
+  scriptId: 10000,
+  lineNumber: 0,
+  columnNumber: 5,
+  allocations: [],
+  children: [anonymousHeapNode]
+};
+
+const anonymousFunctionHeapLines = [
+  {functionId: 1, line: 1},
+];
+
+const anonymousFunctionHeapFunctions = [
+  new perftools.profiles.Function({id: 1, name: 5, systemName: 5, filename: 6}),
+];
+
+const anonymousFunctionHeapLocations = [
+  new perftools.profiles.Location({line: [heapLines[0]], id: 1}),
+];
+
+export const anonymousFunctionHeapProfile: perftools.profiles.IProfile = {
+  sampleType: [
+    new perftools.profiles.ValueType({type: 1, unit: 2}),
+    new perftools.profiles.ValueType({type: 3, unit: 4}),
+  ],
+  sample: [
+    new perftools.profiles.Sample({locationId: [1], value: [1, 5], label: []}),
+  ],
+  location: anonymousFunctionHeapLocations,
+  function: anonymousFunctionHeapFunctions,
+  stringTable: [
+    '',
+    'samples',
+    'count',
+    'space',
+    'bytes',
+    '(anonymous)',
+    'main',
+  ],
+  timeNanos: 0,
+  durationNanos: 10 * 1000 * 1000 * 1000,
+  periodType: new perftools.profiles.ValueType({type: 3, unit: 4}),
+  period: 524288
+};
+
+const anonymousFunctionTimeNode = {
+  scriptName: 'main',
+  scriptId: 2,
+  lineNumber: 1,
+  columnNumber: 5,
+  hitCount: 1,
+  children: []
+};
+
+const anonymousFunctionTimeRoot = {
+  name: '(root)',
+  scriptName: 'root',
+  scriptId: 0,
+  lineNumber: 0,
+  columnNumber: 0,
+  hitCount: 0,
+  children: [anonymousFunctionTimeNode]
+};
+
+export const v8AnonymousFunctionTimeProfile: TimeProfile = {
+  startTime: 0,
+  endTime: 10 * 1000,
+  topDownRoot: anonymousFunctionTimeRoot,
+};
+
+const anonymousFunctionTimeLines = [
+  {functionId: 1, line: 1},
+];
+
+const anonymousFunctionTimeFunctions = [
+  new perftools.profiles.Function({id: 1, name: 5, systemName: 5, filename: 6}),
+];
+
+const anonymousFunctionTimeLocations = [
+  new perftools.profiles.Location({
+    line: [timeLines[0]],
+    id: 1,
+  }),
+];
+
+export const anonymousFunctionTimeProfile: perftools.profiles.IProfile = {
+  sampleType: [
+    new perftools.profiles.ValueType({type: 1, unit: 2}),
+    new perftools.profiles.ValueType({type: 3, unit: 4}),
+  ],
+  sample: [
+    new perftools.profiles.Sample(
+        {locationId: [1], value: [1, 1000], label: []}),
+  ],
+  location: anonymousFunctionTimeLocations,
+  function: anonymousFunctionTimeFunctions,
+  stringTable: [
+    '',
+    'samples',
+    'count',
+    'time',
+    'microseconds',
+    '(anonymous)',
+    'main',
+  ],
+  timeNanos: 0,
+  durationNanos: 10 * 1000 * 1000 * 1000,
+  periodType: new perftools.profiles.ValueType({type: 3, unit: 4}),
+  period: 1000,
+};

--- a/ts/test/test-profile-serializer.ts
+++ b/ts/test/test-profile-serializer.ts
@@ -17,7 +17,8 @@
 import {perftools} from '../../proto/profile';
 import {serializeHeapProfile, serializeTimeProfile} from '../src/profilers/profile-serializer';
 import {TimeProfile, TimeProfileNode} from '../src/v8-types';
-import {heapProfile, timeProfile, v8HeapProfile, v8TimeProfile} from './profiles-for-tests';
+
+import {anonymousFunctionHeapProfile, anonymousFunctionTimeProfile, heapProfile, timeProfile, v8AnonymousFunctionHeapProfile, v8AnonymousFunctionTimeProfile, v8HeapProfile, v8TimeProfile} from './profiles-for-tests';
 
 let assert = require('assert');
 
@@ -26,11 +27,21 @@ describe('serializeTimeProfile', () => {
     const timeProfileOut = serializeTimeProfile(v8TimeProfile, 1000);
     assert.deepEqual(timeProfileOut, timeProfile);
   });
+  it('should produce expected profile when there is anyonmous function', () => {
+    const heapProfileOut =
+        serializeTimeProfile(v8AnonymousFunctionTimeProfile, 1000);
+    assert.deepEqual(heapProfileOut, anonymousFunctionTimeProfile);
+  });
 });
 
 describe('serializeHeapProfile', () => {
   it('should produce expected profile', () => {
     const heapProfileOut = serializeHeapProfile(v8HeapProfile, 0, 512 * 1024);
     assert.deepEqual(heapProfileOut, heapProfile);
+  });
+  it('should produce expected profile when there is anyonmous function', () => {
+    const heapProfileOut = serializeHeapProfile(
+        v8AnonymousFunctionHeapProfile, 0, 10 * 1000 * 1000 * 1000, 512 * 1024);
+    assert.deepEqual(heapProfileOut, anonymousFunctionHeapProfile);
   });
 });

--- a/ts/test/test-profile-serializer.ts
+++ b/ts/test/test-profile-serializer.ts
@@ -40,8 +40,8 @@ describe('serializeHeapProfile', () => {
     assert.deepEqual(heapProfileOut, heapProfile);
   });
   it('should produce expected profile when there is anyonmous function', () => {
-    const heapProfileOut = serializeHeapProfile(
-        v8AnonymousFunctionHeapProfile, 0, 10 * 1000 * 1000 * 1000, 512 * 1024);
+    const heapProfileOut =
+        serializeHeapProfile(v8AnonymousFunctionHeapProfile, 0, 512 * 1024);
     assert.deepEqual(heapProfileOut, anonymousFunctionHeapProfile);
   });
 });


### PR DESCRIPTION
This is a regression from #34.
If no function name is specified, the function name should be recorded as  '(anonymous)' .
