### PR TITLE
chore: use stricter semver range for typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "nyc": "^11.2.1",
     "protobufjs": "~6.8.0",
     "sinon": "^4.0.1",
-    "typescript": "^2.6.1"
+    "typescript": "~2.6.x"
   },
   "files": [
     "build/src",


### PR DESCRIPTION
TypeScript famously doesn't follow semver. To avoid unnecessary
breakages in CI due, let's use a stricter semver range.