### PR TITLE
add out/src to files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .nyc_output
 .vscode
 build
+out
 node_modules

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typescript": "~2.6.x"
   },
   "files": [
-    "build/src",
+    "out/src",
     "bindings",
     "proto",
     "binding.gyp",
@@ -64,7 +64,7 @@
   "nyc": {
     "exclude": [
       "proto",
-      "build/test"
+      "out/test"
     ]
   }
 }


### PR DESCRIPTION
After #52, npm package did not include src files and code coverage of tests was added back to code coverage.
This change fixes that.