### PR TITLE
fix: make duration in RequestProfile optional, so Heap Profiles do not have to have durations

### DIFF
--- a/ts/src/profiler.ts
+++ b/ts/src/profiler.ts
@@ -66,7 +66,7 @@ export interface Deployment {
 export interface RequestProfile {
   name: string;
   profileType?: string;
-  duration: string;
+  duration?: string;
   profileBytes?: string;
   deployment?: Deployment;
   labels?: {instance?: string};
@@ -95,7 +95,7 @@ function isDeployment(deployment: any): deployment is Deployment {
 function isRequestProfile(prof: any): prof is RequestProfile {
   return prof && typeof prof.name === 'string' &&
       typeof prof.profileType === 'string' &&
-      typeof prof.duration === 'string' &&
+      (prof.duration === undefined || typeof prof.duration === 'string') &&
       (prof.labels === undefined || prof.labels.instance === undefined ||
        typeof prof.labels.instance === 'string') &&
       (prof.deployment === undefined || isDeployment(prof.deployment));
@@ -351,6 +351,9 @@ export class Profiler extends common.ServiceObject {
   async writeTimeProfile(prof: RequestProfile): Promise<RequestProfile> {
     if (!this.timeProfiler) {
       throw Error('Cannot collect time profile, time profiler not enabled.');
+    }
+    if (prof.duration === undefined) {
+      throw Error('Cannot collect time profile, duration is undefined.');
     }
     const durationMillis = parseDuration(prof.duration);
     if (!durationMillis) {

--- a/ts/src/profiler.ts
+++ b/ts/src/profiler.ts
@@ -80,12 +80,7 @@ function isDeployment(deployment: any): deployment is Deployment {
   return (deployment.projectId === undefined ||
           typeof deployment.projectId === 'string') &&
       (deployment.target === undefined ||
-       typeof deployment.target === 'string') &&
-      (deployment.labels === undefined ||
-       (deployment.labels.zone === undefined ||
-        typeof deployment.labels.zone === 'string') &&
-           (deployment.labels.version === undefined ||
-            typeof deployment.labels.zone === 'string'));
+       typeof deployment.target === 'string');
 }
 
 /**

--- a/ts/test/test-profiler.ts
+++ b/ts/test/test-profiler.ts
@@ -107,7 +107,6 @@ describe('Profiler', () => {
          const requestProf = {
            name: 'projects/12345678901/test-projectId',
            profileType: 'HEAP',
-           duration: '10s',
            labels: {instance: 'test-instance'}
          };
          const prof = await profiler.profile(requestProf);
@@ -194,7 +193,6 @@ describe('Profiler', () => {
          const requestProf = {
            name: 'projects/12345678901/test-projectId',
            profileType: 'HEAP',
-           duration: '10s',
            labels: {instance: 'test-instance'}
          };
 
@@ -220,7 +218,6 @@ describe('Profiler', () => {
       const requestProf = {
         name: 'projects/12345678901/test-projectId',
         profileType: 'HEAP',
-        duration: '10s',
         labels: {instance: 'test-instance'}
       };
       try {
@@ -383,6 +380,25 @@ describe('Profiler', () => {
          assert.ok(
              requestProfileMock.isDone(), 'expected call to create profile');
        });
+    it('should receive heap profile response without error.', async () => {
+      const config = extend(true, {}, testConfig);
+      config.disableHeap = true;
+      const response = {
+        name: 'projects/12345678901/test-projectId',
+        profileType: 'HEAP',
+        labels: {instance: config.instance}
+      };
+      nockOauth2();
+      const requestProfileMock =
+          nock(API)
+              .post('/projects/' + testConfig.projectId + '/profiles')
+              .once()
+              .reply(200, response);
+      const profiler = new Profiler(testConfig);
+      const actualResponse = await profiler.createProfile();
+      assert.deepEqual(response, actualResponse);
+      assert.ok(requestProfileMock.isDone(), 'expected call to create profile');
+    });
     it('should not have instance and zone in request body when instance and' +
            ' zone undefined',
        async () => {


### PR DESCRIPTION
Right now, duration is a required field of RequestProfile. This does not make sense because heap profiles do not need to have a duration.

Prior to this change, when attempting to collect heap profiles, the following error would occur:
```
Error collecting and uploading profile: ApiError: Request contains an invalid argument
```