### PR TITLE
fix: fix ESOCKETTIMEDOUT Error by increasing timeout to 1 hour for createProfile()

### DIFF
--- a/ts/src/profiler.ts
+++ b/ts/src/profiler.ts
@@ -268,10 +268,10 @@ export class Profiler extends common.ServiceObject {
       body: reqBody,
       json: true,
 
-      // Default timeout for for request is 1 minute, but request to create
+      // Default timeout for for a request is 1 minute, but request to create
       // profile is designed to hang until it is time to collect a profile
       // (up to one hour).
-      timeout: 60 * 60 * 1000,
+      timeout: parseDuration('1h'),
     };
 
     this.logger.debug(`Attempting to create profile.`);

--- a/ts/src/profiler.ts
+++ b/ts/src/profiler.ts
@@ -267,6 +267,7 @@ export class Profiler extends common.ServiceObject {
       uri: '/profiles',
       body: reqBody,
       json: true,
+      timeout: 60 * 60 * 1000,
     };
 
     this.logger.debug(`Attempting to create profile.`);

--- a/ts/src/profiler.ts
+++ b/ts/src/profiler.ts
@@ -267,6 +267,10 @@ export class Profiler extends common.ServiceObject {
       uri: '/profiles',
       body: reqBody,
       json: true,
+
+      // Default timeout for for request is 1 minute, but request to create
+      // profile is designed to hang until it is time to collect a profile
+      // (up to one hour).
       timeout: 60 * 60 * 1000,
     };
 

--- a/ts/test/test-profiler.ts
+++ b/ts/test/test-profiler.ts
@@ -267,7 +267,6 @@ describe('Profiler', () => {
 
       uploaded.profileBytes = undefined;
       assert.deepEqual(uploaded, requestProf);
-
     });
     it('should send request to upload heap profile.', async () => {
       const requestProf = {


### PR DESCRIPTION
Fixes #70 

I tested by running 8 copies of the acmeAir app both before and after this change (for about 10 minutes). Before, ESOCKETTIMEDOUT errors occurred on every request to createProfile(), after, no ESOCKETTIMEDOUT errors were observed.