### PR TITLE
chore: upgrade nan dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@google-cloud/common": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.14.0.tgz",
-      "integrity": "sha1-xWA4KXJH6nKnUNUUVegBcQl2rEM=",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.15.1.tgz",
+      "integrity": "sha512-cnVtHLvyiSQvb1RzXWDp7PA1sA8Jmc47+wp/xwHwdGOlQZfKog5iluZ0C/LB8iklFXpcTwlNMorqLuZ/qH0DDA==",
       "requires": {
         "array-uniq": "1.0.3",
         "arrify": "1.0.1",
@@ -16,7 +16,7 @@
         "duplexify": "3.5.1",
         "ent": "2.2.0",
         "extend": "3.0.1",
-        "google-auto-auth": "0.7.2",
+        "google-auto-auth": "0.8.0",
         "is": "3.2.1",
         "log-driver": "1.2.5",
         "methmeth": "1.1.0",
@@ -27,37 +27,66 @@
         "stream-events": "1.0.2",
         "string-format-obj": "1.1.0",
         "through2": "2.0.3"
+      },
+      "dependencies": {
+        "gcp-metadata": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.3.1.tgz",
+          "integrity": "sha512-5kJPX/RXuqoLmHiOOgkSDk/LI0QaXpEvZ3pvQP4ifjGGDKZKVSOjL/GcDjXA5kLxppFCOjmmsu0Uoop9d1upaQ==",
+          "requires": {
+            "extend": "3.0.1",
+            "retry-request": "3.1.1"
+          }
+        },
+        "google-auth-library": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.12.0.tgz",
+          "integrity": "sha512-79qCXtJ1VweBmmLr4yLq9S4clZB2p5Y+iACvuKk9gu4JitEnPc+bQFmYvtCYehVR44MQzD1J8DVmYW2w677IEw==",
+          "requires": {
+            "gtoken": "1.2.3",
+            "jws": "3.1.4",
+            "lodash.isstring": "4.0.1",
+            "lodash.merge": "4.6.0",
+            "request": "2.83.0"
+          }
+        },
+        "google-auto-auth": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.8.0.tgz",
+          "integrity": "sha512-ul3Bvh+3S83xSrD7KjD8xyJIVPx95Yb5yd7y5P+c2Ip2zlQIbDXw0lFyfswUJQEnPmh6iWQw8oQcfgrgbGF3VA==",
+          "requires": {
+            "async": "2.6.0",
+            "gcp-metadata": "0.3.1",
+            "google-auth-library": "0.12.0",
+            "request": "2.83.0"
+          }
+        }
       }
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
-      "dev": true
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "dev": true
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
     },
     "@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "dev": true
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
     },
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
-      "dev": true
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
-      "dev": true,
       "requires": {
         "@protobufjs/aspromise": "1.1.2",
         "@protobufjs/inquire": "1.1.0"
@@ -66,32 +95,27 @@
     "@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
-      "dev": true
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
-      "dev": true
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
-      "dev": true
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
-      "dev": true
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
-      "dev": true
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@types/delay": {
       "version": "2.0.1",
@@ -117,8 +141,7 @@
     "@types/long": {
       "version": "3.0.32",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
-      "integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA==",
-      "dev": true
+      "integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA=="
     },
     "@types/mocha": {
       "version": "2.2.44",
@@ -1072,39 +1095,6 @@
         "ini": "1.3.4"
       }
     },
-    "google-auth-library": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-      "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
-      "requires": {
-        "gtoken": "1.2.3",
-        "jws": "3.1.4",
-        "lodash.noop": "3.0.1",
-        "request": "2.83.0"
-      }
-    },
-    "google-auto-auth": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.7.2.tgz",
-      "integrity": "sha512-ux2n2AE2g3+vcLXwL4dP/M12SFMRX5dzCzBfhAEkTeAB7dpyGdOIEj7nmUx0BHKaCcUQrRWg9kT63X/Mmtk1+A==",
-      "requires": {
-        "async": "2.6.0",
-        "gcp-metadata": "0.3.1",
-        "google-auth-library": "0.10.0",
-        "request": "2.83.0"
-      },
-      "dependencies": {
-        "gcp-metadata": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.3.1.tgz",
-          "integrity": "sha512-5kJPX/RXuqoLmHiOOgkSDk/LI0QaXpEvZ3pvQP4ifjGGDKZKVSOjL/GcDjXA5kLxppFCOjmmsu0Uoop9d1upaQ==",
-          "requires": {
-            "extend": "3.0.1",
-            "retry-request": "3.1.1"
-          }
-        }
-      }
-    },
     "google-p12-pem": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-0.1.2.tgz",
@@ -1566,10 +1556,15 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
-    "lodash.noop": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz",
-      "integrity": "sha1-OBiPTWUKOkdCWEObluxFsyYXEzw="
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.merge": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
     },
     "log-driver": {
       "version": "1.2.5",
@@ -1585,8 +1580,7 @@
     "long": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
-      "dev": true
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -1761,9 +1755,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
     },
     "nise": {
       "version": "1.2.0",
@@ -3833,7 +3827,6 @@
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.0.tgz",
       "integrity": "sha512-47Y49f5JN5Qsbxas2TyI2zFO8j9GpQAQm5thf54fr2O8qcP/jkIXYxmYx1hN2WQFAhESU1xpVn5NWVDBB8WFnw==",
-      "dev": true,
       "requires": {
         "@protobufjs/aspromise": "1.1.2",
         "@protobufjs/base64": "1.1.2",
@@ -3853,8 +3846,7 @@
         "@types/node": {
           "version": "7.0.46",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.46.tgz",
-          "integrity": "sha512-u+JAi1KtmaUoU/EHJkxoiuvzyo91FCE41Z9TZWWcOUU3P8oUdlDLdrGzCGWySPgbRMD17B0B+1aaJLYI9egQ6A==",
-          "dev": true
+          "integrity": "sha512-u+JAi1KtmaUoU/EHJkxoiuvzyo91FCE41Z9TZWWcOUU3P8oUdlDLdrGzCGWySPgbRMD17B0B+1aaJLYI9egQ6A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "delay": "^2.0.0",
     "extend": "^3.0.1",
     "gcp-metadata": "^0.4.0",
-    "nan": "^2.1.0",
+    "nan": "^2.8.0",
     "parse-duration": "^0.1.1",
     "pify": "^3.0.0",
     "protobufjs": "~6.8.0",


### PR DESCRIPTION
This gets rid of the deprecation warnings when building with node 9.

    CXX(target) Release/obj.target/sampling_heap_profiler/bindings/sampling-heap-profiler.o
    In file included from ../bindings/sampling-heap-profiler.cc:18:
    In file included from ../node_modules/nan/nan.h:192:
    ../node_modules/nan/nan_maybe_43_inl.h:112:15: warning: 'ForceSet' is deprecated [-Wdeprecated-declarations]
       return obj->ForceSet(isolate->GetCurrentContext(), key, value, attribs);