### PR TITLE
fix: fix travis tests on node 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/profiler",
-  "version": "0.1.9",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1158,9 +1158,9 @@
       }
     },
     "gts": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/gts/-/gts-0.5.2.tgz",
-      "integrity": "sha512-XnsRWIBBAwXx+ta/ra0foqQ7D1nUqZ0GbL2I5vJK96wK14X16xl3uaMGb1D+DZDWfaQAH7h+R1F7KEuUfvDsNQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/gts/-/gts-0.5.3.tgz",
+      "integrity": "sha512-MiC5I1cAYjuGq68Xc9esn1qQcfl/on154+Oux8y6xWv03Ql9DGGsAokFVzgqNFDV65wd38uXYcPNaeeIl/EOjg==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -71,9 +71,9 @@ export async function initConfig(config: Config): Promise<ProfilerConfig> {
   }
 
   let envSetConfig: Config = {};
-  if (process.env.hasOwnProperty('GCLOUD_PROFILER_CONFIG')) {
-    envSetConfig =
-        require(path.resolve(process.env.GCLOUD_PROFILER_CONFIG)) as Config;
+  let val =  require(path.resolve(process.env.GCLOUD_PROFILER_CONFIG!)) as Config;
+  if (val) {
+    envSetConfig = val;
   }
 
   const mergedConfig =


### PR DESCRIPTION
Travis tests with node 6 are failing with:
```
ts/src/index.ts(76,30): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
76         require(path.resolve(process.env.GCLOUD_PROFILER_CONFIG)) as Config;
```

This PR adds a cast to process.env.GCLOUD_PROFILER_CONFIG, so tests again pass on node 6. 
