### PR TITLE
feat: add source mapping to tests for better stack traces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/profiler",
-  "version": "0.1.6",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -159,6 +159,14 @@
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.1.2.tgz",
       "integrity": "sha512-fL6bJHYRzbw/7ofbKiJ65SOAasoe5mZhHNSYKxWsF3sGl/arhRwDPwXJqM1xofKNTQD14HNX9VruicM7pm++mQ==",
       "dev": true
+    },
+    "@types/source-map-support": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.4.0.tgz",
+      "integrity": "sha512-9oVAi1Jlr274pbMGPEe0S3IPImV9knVNafa6E4MookD/fjOZAE6EmLkFX5ZjtZ9OXNPi2FCIZzUSMvwAUUKeSg==",
+      "requires": {
+        "@types/node": "8.5.2"
+      }
     },
     "ajv": {
       "version": "5.5.2",
@@ -4237,6 +4245,21 @@
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
         "hoek": "4.2.0"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
+      "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.6.1"
       }
     },
     "spdx-compare": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "out/src/index.d.ts",
   "scripts": {
     "install": "node-gyp rebuild",
-    "test": "nyc mocha out/test/test-*.js && nyc --no-clean mocha out/system-test/test-*.js --timeout=60000",
+    "test": "nyc mocha --require source-map-support/register out/test/test-*.js && nyc --no-clean mocha --require source-map-support/register  out/system-test/test-*.js --timeout=60000",
     "check": "gts check",
     "clean": "gts clean",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json",
@@ -57,6 +57,7 @@
     "nock": "^9.0.22",
     "nyc": "^11.2.1",
     "sinon": "^4.0.1",
+    "source-map-support": "^0.5.0",
     "ts-mockito": "^2.2.5",
     "typescript": "~2.6.x"
   },

--- a/ts/src/profiler.ts
+++ b/ts/src/profiler.ts
@@ -159,13 +159,18 @@ function isBackoffResponseError(err: Error): err is BackoffResponseError {
  */
 export class Retryer {
   private nextBackoffMillis: number;
+
+  // For testing. Allows Math.random() to be replaced with non-random function.
+  private random: () => number;
+
   constructor(
       readonly initialBackoffMillis: number, readonly backoffCapMillis: number,
-      readonly backoffMultiplier: number) {
+      readonly backoffMultiplier: number, random = Math.random) {
     this.nextBackoffMillis = this.initialBackoffMillis;
+    this.random = random;
   }
   getBackoff(): number {
-    const curBackoff = Math.random() * this.nextBackoffMillis;
+    const curBackoff = this.random() * this.nextBackoffMillis;
     this.nextBackoffMillis = Math.min(
         this.backoffMultiplier * this.nextBackoffMillis, this.backoffCapMillis);
     return curBackoff;

--- a/ts/test/test-profiler.ts
+++ b/ts/test/test-profiler.ts
@@ -82,18 +82,10 @@ function nockOauth2(): nock.Scope {
       });
 }
 
+
 describe('Retryer', () => {
-  let randomStub: sinon.SinonStub|undefined;
-  before(() => {
-    randomStub = sinon.stub(Math, 'random').returns(0.5);
-  });
-  after(() => {
-    if (randomStub) {
-      randomStub.restore();
-    }
-  });
   it('should backoff until max-backoff reached', () => {
-    const retryer = new Retryer(1000, 1000000, 5);
+    const retryer = new Retryer(1000, 1000000, 5, () => 0.5);
     assert.equal(retryer.getBackoff(), 0.5 * 1000);
     assert.equal(retryer.getBackoff(), 0.5 * 5000);
     assert.equal(retryer.getBackoff(), 0.5 * 25000);


### PR DESCRIPTION
fixes: #68 

Tests with source mapping has previously failed when Math.random() was stubbed with sinon. This adds source-mapping back and modifies code so that Math.random() does not need to be stubbed.