### PR TITLE
chore: Update @types/node to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/long": "^3.0.32",
     "@types/mocha": "^2.2.43",
     "@types/nock": "^9.1.0",
-    "@types/node": "^8.0.30",
+    "@types/node": "^9.3.0",
     "@types/pify": "^3.0.0",
     "@types/pretty-ms": "^3.0.0",
     "@types/request": "^2.0.7",

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -71,9 +71,9 @@ export async function initConfig(config: Config): Promise<ProfilerConfig> {
   }
 
   let envSetConfig: Config = {};
-  if (process.env.GCLOUD_PROFILER_CONFIG) {
-    envSetConfig =
-        require(path.resolve(process.env.GCLOUD_PROFILER_CONFIG)) as Config;
+  const val = process.env.GCLOUD_PROFILER_CONFIG;
+  if (val) {
+    envSetConfig = require(path.resolve(val)) as Config;
   }
 
   const mergedConfig =


### PR DESCRIPTION
Greenkeeper's PR #104 for updating @types/node to 9.3.0 has failing tests. 
This change updates @types/node and modified code so tests continue to pass (specifically ts/src/index.ts has a change).
