### PR TITLE
Revert "Update @google-cloud/common to the latest version 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@google-cloud/common": "^0.16.0",
+    "@google-cloud/common": "^0.15.0",
     "bindings": "^1.2.1",
     "delay": "^2.0.0",
     "extend": "^3.0.1",


### PR DESCRIPTION
Reverts GoogleCloudPlatform/cloud-profiler-nodejs#124

After making this change, the projectId is not retrieved from the environment variable on GCE.
I will update this dependency more carefully in a separate PR.