### PR TITLE
chore: update gcp-metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -276,7 +276,6 @@
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
       "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
-      "dev": true,
       "requires": {
         "follow-redirects": "1.3.0",
         "is-buffer": "1.1.6"
@@ -804,7 +803,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -1027,7 +1025,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.3.0.tgz",
       "integrity": "sha1-9oSHH8EW0uMp/aVe9naH9Pq8kFw=",
-      "dev": true,
       "requires": {
         "debug": "3.1.0"
       }
@@ -1063,12 +1060,13 @@
       "dev": true
     },
     "gcp-metadata": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.4.1.tgz",
-      "integrity": "sha512-yFE7v+NyoMiTOi2L6r8q87eVbiZCKooJNPKXTHhBStga8pwwgWofK9iHl00qd0XevZxcpk7ORaEL/ALuTvlaGQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.5.0.tgz",
+      "integrity": "sha512-G+haBuoUrnLzzJfnAuefG2yR0TC7Pgn8iw9L7YgacbBeQYx+/QiTulmYfetj923HMz0nWNW7Q7/fmNCLFMMN4Q==",
       "requires": {
+        "axios": "0.17.1",
         "extend": "3.0.1",
-        "retry-request": "3.3.1"
+        "retry-axios": "0.3.0"
       }
     },
     "get-stream": {
@@ -1370,8 +1368,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -1851,8 +1848,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -4127,6 +4123,11 @@
         "onetime": "2.0.1",
         "signal-exit": "3.0.2"
       }
+    },
+    "retry-axios": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-0.3.0.tgz",
+      "integrity": "sha512-6vOCghodB5p5N/ZOqug7A3WsT42TULZ7NErUi4lP3KtwtXgz4hE/43LWHsFuHuBfXRmOm/tjXBWAjnObrcy+yg=="
     },
     "retry-request": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bindings": "^1.2.1",
     "delay": "^2.0.0",
     "extend": "^3.0.1",
-    "gcp-metadata": "^0.4.0",
+    "gcp-metadata": "^0.5.0",
     "nan": "^2.8.0",
     "parse-duration": "^0.1.1",
     "pify": "^3.0.0",

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -34,9 +34,8 @@ const pjson = require('../../package.json');
  * Throws error if there is a problem accessing metadata API.
  */
 async function getMetadataInstanceField(field: string): Promise<string> {
-  const [response, metadata] =
-      await pify(gcpMetadata.instance, {multiArgs: true})(field);
-  return metadata;
+  const res = await gcpMetadata.instance(field);
+  return res.data;
 }
 
 function hasService(config: Config):

--- a/ts/test/test-init-config.ts
+++ b/ts/test/test-init-config.ts
@@ -74,10 +74,9 @@ describe('initConfig', () => {
   it('should not modify specified fields when on GCE', async () => {
     metadataStub = sinon.stub(gcpMetadata, 'instance');
     metadataStub.withArgs('name')
-        .callsArgWith(1, null, undefined, 'gce-instance')
+        .resolves({data: 'gce-instance'})
         .withArgs('zone')
-        .callsArgWith(
-            1, null, undefined, 'projects/123456789012/zones/gce-zone');
+        .resolves({data: 'projects/123456789012/zones/gce-zone'});
 
     const config = {
       logLevel: 2,
@@ -95,10 +94,9 @@ describe('initConfig', () => {
   it('should get zone and instance from GCE', async () => {
     metadataStub = sinon.stub(gcpMetadata, 'instance');
     metadataStub.withArgs('name')
-        .callsArgWith(1, null, undefined, 'gce-instance')
+        .resolves({data: 'gce-instance'})
         .withArgs('zone')
-        .callsArgWith(
-            1, null, undefined, 'projects/123456789012/zones/gce-zone');
+        .resolves({data: 'projects/123456789012/zones/gce-zone'});
 
     const config = {
       projectId: 'projectId',
@@ -208,10 +206,9 @@ describe('initConfig', () => {
            './ts/test/fixtures/test-config.json';
        metadataStub = sinon.stub(gcpMetadata, 'instance');
        metadataStub.withArgs('name')
-           .callsArgWith(1, null, undefined, 'gce-instance')
+           .resolves({data: 'gce-instance'})
            .withArgs('zone')
-           .callsArgWith(
-               1, null, undefined, 'projects/123456789012/zones/gce-zone');
+           .resolves({data: 'projects/123456789012/zones/gce-zone'});
        const config = {};
        const expConfig = {
          projectId: 'process-projectId',
@@ -238,10 +235,9 @@ describe('initConfig', () => {
            './ts/test/fixtures/test-config.json';
        metadataStub = sinon.stub(gcpMetadata, 'instance');
        metadataStub.withArgs('name')
-           .callsArgWith(1, null, undefined, 'gce-instance')
+           .resolves({data: 'gce-instance'})
            .withArgs('zone')
-           .callsArgWith(
-               1, null, undefined, 'projects/123456789012/zones/gce-zone');
+           .resolves({data: 'projects/123456789012/zones/gce-zone'});
 
        const config = {
          projectId: 'config-projectId',


### PR DESCRIPTION
Updates gcp-metadata to version 0.5.0.
Also makes the changes so that code uses gcp-metadata's new API.

In addition to running the tests, I also ran a trivial application in GCE and saw that the zone was set in the profiles after this update.
