### PR TITLE
feat: add field to config so user can use test API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.2"
+        "@types/node": "9.4.5"
       }
     },
     "@types/long": {
@@ -115,7 +115,7 @@
       "integrity": "sha512-tE1SYtNG3I3atRVPELSGN2FJJJtPg3O/G0tycYSyzeDqdAbdLPRH089LhpWYA5M/iHeWHkVZq/b0OVKngcK0Eg==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.2"
+        "@types/node": "9.4.5"
       }
     },
     "@types/nock": {
@@ -124,13 +124,14 @@
       "integrity": "sha512-Ykk50z1MKpHDRmnBJb6kn3rU03cCsbjHmqCzY3eyeDNxdz3mrgbbwwXRXzBnPXkD9qzGh1ZU9XLdbQVp6i0+gQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.2"
+        "@types/node": "9.4.5"
       }
     },
     "@types/node": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.2.tgz",
-      "integrity": "sha512-KA4GKOpgXnrqEH2eCVhiv2CsxgXGQJgV1X0vsGlh+WCnxbeAE1GT44ZsTU1IN5dEeV/gDupKa7gWo08V5IxWVQ=="
+      "version": "9.4.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.5.tgz",
+      "integrity": "sha512-DvC7bzO5797bkApgukxouHmkOdYN2D0yL5olw0RncDpXUa6n39qTVsUi/5g2QJjPgl8qn4zh+4h0sofNoWGLRg==",
+      "dev": true
     },
     "@types/pify": {
       "version": "3.0.0",
@@ -151,7 +152,7 @@
       "dev": true,
       "requires": {
         "@types/form-data": "2.2.1",
-        "@types/node": "8.5.2"
+        "@types/node": "9.4.5"
       }
     },
     "@types/sinon": {
@@ -159,14 +160,6 @@
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.1.2.tgz",
       "integrity": "sha512-fL6bJHYRzbw/7ofbKiJ65SOAasoe5mZhHNSYKxWsF3sGl/arhRwDPwXJqM1xofKNTQD14HNX9VruicM7pm++mQ==",
       "dev": true
-    },
-    "@types/source-map-support": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.4.0.tgz",
-      "integrity": "sha512-9oVAi1Jlr274pbMGPEe0S3IPImV9knVNafa6E4MookD/fjOZAE6EmLkFX5ZjtZ9OXNPi2FCIZzUSMvwAUUKeSg==",
-      "requires": {
-        "@types/node": "8.5.2"
-      }
     },
     "ajv": {
       "version": "5.5.2",
@@ -1483,9 +1476,9 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "js-green-licenses": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.2.0.tgz",
-      "integrity": "sha512-AkUDqKfvOREpd+ZbZRIdP5YRbEyNsyxMBgvMrfjs4zk5TpYJondN+Xcvm57tj7e1cgYaoBg5yx9g99eXEoYuqA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.4.0.tgz",
+      "integrity": "sha512-LpkL/9coWxNUmJ9/jxng3uvcLK6Qso2yaz7QBjO+atwtX/xmt8MrCtbkolYdhPZl/fq5dRs7Q7BLA8Ne3DKZ2w==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -1494,7 +1487,8 @@
         "package-json": "4.0.1",
         "pify": "3.0.0",
         "spdx-correct": "2.0.4",
-        "spdx-satisfies": "0.1.3"
+        "spdx-satisfies": "0.1.3",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "spdx-correct": {
@@ -1809,9 +1803,9 @@
       }
     },
     "mocha": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.0.tgz",
+      "integrity": "sha512-ukB2dF+u4aeJjc6IGtPNnJXfeby5d4ZqySlIBT0OEyva/DrMjVm5HkQxKnHDLKEfEQBsEnwTg9HHhtPHJdTd8w==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -3977,8 +3971,15 @@
         "@protobufjs/pool": "1.1.0",
         "@protobufjs/utf8": "1.1.0",
         "@types/long": "3.0.32",
-        "@types/node": "8.5.2",
+        "@types/node": "8.9.3",
         "long": "3.2.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.9.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.3.tgz",
+          "integrity": "sha512-wqrPE4Uvj2fmL0E5JFQiY7D/5bAKvVUfWTnQ5NEV35ULkAU0j3QuqIi9Qyrytz8M5hsrh8Kijt+FsdLQaZR+IA=="
+        }
       }
     },
     "pseudomap": {

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -102,6 +102,10 @@ export interface Config extends AuthenticationConfig {
   // too large.
   // https://nodejs.org/dist/latest-v9.x/docs/api/timers.html#timers_settimeout_callback_delay_args.
   serverBackoffCapMillis?: number;
+
+  // Use test-cloudprofiler.sandbox.googleapis.com instead of
+  // cloudprofiler.googleapis.com when this is set to true.
+  useTestApi?: boolean;
 }
 
 // Interface for an initialized config.
@@ -120,6 +124,7 @@ export interface ProfilerConfig extends AuthenticationConfig {
   backoffCapMillis: number;
   backoffMultiplier: number;
   serverBackoffCapMillis: number;
+  useTestApi: boolean;
 }
 
 // Default values for configuration for a profiler.
@@ -134,6 +139,7 @@ export const defaultConfig = {
   initialBackoffMillis: 1000,
   backoffCapMillis: parseDuration('1h'),
   backoffMultiplier: 1.3,
+  useTestApi: false,
 
   // This is the largest duration for setTimeout which does not cause it to
   // run immediately.

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -103,7 +103,8 @@ export interface Config extends AuthenticationConfig {
   // https://nodejs.org/dist/latest-v9.x/docs/api/timers.html#timers_settimeout_callback_delay_args.
   serverBackoffCapMillis?: number;
 
-  // Allows user to specify API URL other than cloudprofiler.googleapis.com/v2.
+  // Allows user to specify API URL other than
+  // https://cloudprofiler.googleapis.com/v2.
   baseApiUrl?: string;
 }
 

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -103,9 +103,8 @@ export interface Config extends AuthenticationConfig {
   // https://nodejs.org/dist/latest-v9.x/docs/api/timers.html#timers_settimeout_callback_delay_args.
   serverBackoffCapMillis?: number;
 
-  // Use test-cloudprofiler.sandbox.googleapis.com instead of
-  // cloudprofiler.googleapis.com when this is set to true.
-  useTestApi?: boolean;
+  // Allows user to specify API URL other than cloudprofiler.googleapis.com/v2.
+  baseApiUrl?: string;
 }
 
 // Interface for an initialized config.
@@ -124,7 +123,7 @@ export interface ProfilerConfig extends AuthenticationConfig {
   backoffCapMillis: number;
   backoffMultiplier: number;
   serverBackoffCapMillis: number;
-  useTestApi: boolean;
+  baseApiUrl: string;
 }
 
 // Default values for configuration for a profiler.
@@ -139,7 +138,7 @@ export const defaultConfig = {
   initialBackoffMillis: 1000,
   backoffCapMillis: parseDuration('1h'),
   backoffMultiplier: 1.3,
-  useTestApi: false,
+  baseApiUrl: 'https://cloudprofiler.googleapis.com/v2',
 
   // This is the largest duration for setTimeout which does not cause it to
   // run immediately.

--- a/ts/src/profiler.ts
+++ b/ts/src/profiler.ts
@@ -31,6 +31,7 @@ export const common: Common = require('@google-cloud/common');
 const parseDuration: (str: string) => number = require('parse-duration');
 const pjson = require('../../package.json');
 const API = 'https://cloudprofiler.googleapis.com/v2';
+const TEST_API = 'https://test-cloudprofiler.sandbox.googleapis.com/v2';
 const SCOPE = 'https://www.googleapis.com/auth/monitoring.write';
 const gzip = pify(zlib.gzip);
 
@@ -215,6 +216,7 @@ export class Profiler extends common.ServiceObject {
   private deployment: Deployment;
   private profileTypes: string[];
   private retryer: Retryer;
+  private api: string;
 
   // Public for testing.
   timeProfiler: TimeProfiler|undefined;
@@ -222,13 +224,14 @@ export class Profiler extends common.ServiceObject {
 
   constructor(config: ProfilerConfig) {
     config = common.util.normalizeArguments(null, config);
+    const api = config.useTestApi ? TEST_API : API;
     const serviceConfig = {
-      baseUrl: API,
+      baseUrl: api,
       scopes: [SCOPE],
       packageJson: pjson,
     };
     super({parent: new common.Service(serviceConfig, config), baseUrl: '/'});
-
+    this.api = api;
     this.config = config;
 
     this.logger = new common.logger({
@@ -390,7 +393,7 @@ export class Profiler extends common.ServiceObject {
     }
     const options = {
       method: 'PATCH',
-      uri: API + '/' + prof.name,
+      uri: this.api + '/' + prof.name,
       body: prof,
       json: true,
     };

--- a/ts/src/profiler.ts
+++ b/ts/src/profiler.ts
@@ -30,8 +30,6 @@ import {TimeProfiler} from './profilers/time-profiler';
 export const common: Common = require('@google-cloud/common');
 const parseDuration: (str: string) => number = require('parse-duration');
 const pjson = require('../../package.json');
-const API = 'https://cloudprofiler.googleapis.com/v2';
-const TEST_API = 'https://test-cloudprofiler.sandbox.googleapis.com/v2';
 const SCOPE = 'https://www.googleapis.com/auth/monitoring.write';
 const gzip = pify(zlib.gzip);
 
@@ -216,7 +214,6 @@ export class Profiler extends common.ServiceObject {
   private deployment: Deployment;
   private profileTypes: string[];
   private retryer: Retryer;
-  private api: string;
 
   // Public for testing.
   timeProfiler: TimeProfiler|undefined;
@@ -224,14 +221,12 @@ export class Profiler extends common.ServiceObject {
 
   constructor(config: ProfilerConfig) {
     config = common.util.normalizeArguments(null, config);
-    const api = config.useTestApi ? TEST_API : API;
     const serviceConfig = {
-      baseUrl: api,
+      baseUrl: config.baseApiUrl,
       scopes: [SCOPE],
       packageJson: pjson,
     };
     super({parent: new common.Service(serviceConfig, config), baseUrl: '/'});
-    this.api = api;
     this.config = config;
 
     this.logger = new common.logger({
@@ -393,7 +388,7 @@ export class Profiler extends common.ServiceObject {
     }
     const options = {
       method: 'PATCH',
-      uri: this.api + '/' + prof.name,
+      uri: this.config.baseApiUrl + '/' + prof.name,
       body: prof,
       json: true,
     };

--- a/ts/test/test-init-config.ts
+++ b/ts/test/test-init-config.ts
@@ -51,7 +51,7 @@ describe('initConfig', () => {
     backoffCapMillis: 60 * 60 * 1000,
     backoffMultiplier: 1.3,
     serverBackoffCapMillis: 2147483647,
-    useTestApi: false
+    baseApiUrl: 'https://cloudprofiler.googleapis.com/v2',
   };
 
   it('should not modify specified fields when not on GCE', async () => {
@@ -176,13 +176,13 @@ describe('initConfig', () => {
     assert.deepEqual(initializedConfig, extend(config, internalConfigParams));
   });
 
-  it('should set useTestApi to true', async () => {
+  it('should set baseApiUrl to non-default value', async () => {
     metadataStub = sinon.stub(gcpMetadata, 'instance');
     metadataStub.throwsException('cannot access metadata');
 
     const config = {
       serviceContext: {version: '', service: 'fake-service'},
-      useTestApi: true
+      baseApiUrl: 'https://test-cloudprofiler.sandbox.googleapis.com/v2'
     };
     const expConfig = extend(
         {
@@ -192,7 +192,8 @@ describe('initConfig', () => {
           logLevel: 2
         },
         internalConfigParams);
-    expConfig.useTestApi = true;
+    expConfig.baseApiUrl =
+        'https://test-cloudprofiler.sandbox.googleapis.com/v2';
     const initializedConfig = await initConfig(config);
     assert.deepEqual(initializedConfig, expConfig);
   });

--- a/ts/test/test-init-config.ts
+++ b/ts/test/test-init-config.ts
@@ -50,7 +50,8 @@ describe('initConfig', () => {
     initialBackoffMillis: 1000,
     backoffCapMillis: 60 * 60 * 1000,
     backoffMultiplier: 1.3,
-    serverBackoffCapMillis: 2147483647
+    serverBackoffCapMillis: 2147483647,
+    useTestApi: false
   };
 
   it('should not modify specified fields when not on GCE', async () => {
@@ -173,6 +174,27 @@ describe('initConfig', () => {
     };
     const initializedConfig = await initConfig(config);
     assert.deepEqual(initializedConfig, extend(config, internalConfigParams));
+  });
+
+  it('should set useTestApi to true', async () => {
+    metadataStub = sinon.stub(gcpMetadata, 'instance');
+    metadataStub.throwsException('cannot access metadata');
+
+    const config = {
+      serviceContext: {version: '', service: 'fake-service'},
+      useTestApi: true
+    };
+    const expConfig = extend(
+        {
+          serviceContext: {version: '', service: 'fake-service'},
+          disableHeap: false,
+          disableTime: false,
+          logLevel: 2
+        },
+        internalConfigParams);
+    expConfig.useTestApi = true;
+    const initializedConfig = await initConfig(config);
+    assert.deepEqual(initializedConfig, expConfig);
   });
 
   it('should get values from from environment variable when not specified in config or environment variables',

--- a/ts/test/test-profiler.ts
+++ b/ts/test/test-profiler.ts
@@ -16,6 +16,7 @@
 
 import * as assert from 'assert';
 import * as extend from 'extend';
+import {request} from 'https';
 import * as nock from 'nock';
 import * as pify from 'pify';
 import * as sinon from 'sinon';
@@ -53,10 +54,12 @@ const testConfig: ProfilerConfig = {
   initialBackoffMillis: 1000,
   backoffCapMillis: parseDuration('1h'),
   backoffMultiplier: 1.3,
-  serverBackoffCapMillis: parseDuration('7d')
+  serverBackoffCapMillis: parseDuration('7d'),
+  useTestApi: false
 };
 
 const API = 'https://cloudprofiler.googleapis.com/v2';
+const TEST_API = 'https://test-cloudprofiler.sandbox.googleapis.com/v2';
 
 const mockTimeProfiler = mock(TimeProfiler);
 when(mockTimeProfiler.profile(10 * 1000)).thenReturn(new Promise((resolve) => {
@@ -359,6 +362,40 @@ describe('Profiler', () => {
       profiler.timeProfiler = instance(mockTimeProfiler);
       await profiler.profileAndUpload(requestProf);
     });
+    it('should send request to upload profile to real API without error.',
+       async () => {
+         const requestProf = {
+           name: 'projects/12345678901/test-projectId',
+           duration: '10s',
+           profileType: 'HEAP',
+           labels: {instance: 'test-instance'}
+         };
+         nockOauth2();
+         const apiMock =
+             nock(API).patch('/' + requestProf.name).once().reply(200);
+         const profiler = new Profiler(testConfig);
+         profiler.heapProfiler = instance(mockHeapProfiler);
+         await profiler.profileAndUpload(requestProf);
+         assert.equal(apiMock.isDone(), true, 'completed call to real API');
+       });
+    it('should send request to upload profile to test API without error.',
+       async () => {
+         const requestProf = {
+           name: 'projects/12345678901/test-projectId',
+           duration: '10s',
+           profileType: 'HEAP',
+           labels: {instance: 'test-instance'}
+         };
+         nockOauth2();
+         const apiMock =
+             nock(TEST_API).patch('/' + requestProf.name).once().reply(200);
+         const config = extend(true, {}, testConfig);
+         config.useTestApi = true;
+         const profiler = new Profiler(config);
+         profiler.heapProfiler = instance(mockHeapProfiler);
+         await profiler.profileAndUpload(requestProf);
+         assert.equal(apiMock.isDone(), true, 'completed call to test API');
+       });
   });
   describe('createProfile', () => {
     let requestStub: undefined|sinon.SinonStub;
@@ -392,6 +429,34 @@ describe('Profiler', () => {
       assert.deepEqual(response, actualResponse);
       assert.ok(requestProfileMock.isDone(), 'expected call to create profile');
     });
+    it('should successfully create profile when connected to test api',
+       async () => {
+         const config = extend(true, {}, testConfig);
+         config.disableHeap = true;
+         config.useTestApi = true;
+         const response = {
+           name: 'projects/12345678901/test-projectId',
+           profileType: 'WALL',
+           duration: '10s',
+           deployment: {
+             labels: {version: 'test-version'},
+             projectId: 'test-projectId',
+             target: 'test-service'
+           },
+           labels: {version: config.serviceContext.version}
+         };
+         nockOauth2();
+         const requestProfileMock =
+             nock(TEST_API)
+                 .post('/projects/' + config.projectId + '/profiles')
+                 .once()
+                 .reply(200, response);
+         const profiler = new Profiler(config);
+         const actualResponse = await profiler.createProfile();
+         assert.deepEqual(response, actualResponse);
+         assert.ok(
+             requestProfileMock.isDone(), 'expected call to create profile');
+       });
     it('should successfully create heap profile', async () => {
       const config = extend(true, {}, testConfig);
       config.disableHeap = true;


### PR DESCRIPTION
It's useful when testing the agent to be able to upload profiles to the test API.
This PR adds a field to the config, `baseApiUrl`, which a user can use to set the api url used to something other than `cloudprofiler.googleapis.com`.