### PR TITLE
fix: don't run profiler if incompatible version of node is used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -155,6 +155,12 @@
         "@types/node": "9.4.5"
       }
     },
+    "@types/semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
+      "dev": true
+    },
     "@types/sinon": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.1.2.tgz",
@@ -1896,7 +1902,7 @@
         "mkdirp": "0.5.1",
         "propagate": "0.4.0",
         "qs": "6.5.1",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       },
       "dependencies": {
         "debug": {
@@ -1923,7 +1929,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -1935,7 +1941,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "osenv": "0.1.4",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "validate-npm-package-name": "3.0.0"
       }
     },
@@ -3828,7 +3834,7 @@
         "got": "6.7.1",
         "registry-auth-token": "3.3.1",
         "registry-url": "3.1.0",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "parse-duration": {
@@ -4183,10 +4189,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -4194,7 +4199,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "shebang-command": {
@@ -4523,7 +4528,7 @@
         "glob": "7.1.2",
         "minimatch": "3.0.4",
         "resolve": "1.5.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "tslib": "1.8.1",
         "tsutils": "2.15.0"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "pretty-ms": "^3.1.0",
     "protobufjs": "~6.8.0",
     "request": "^2.83.0",
-    "retry-request": "^3.0.1"
+    "retry-request": "^3.0.1",
+    "semver": "^5.5.0"
   },
   "devDependencies": {
     "@types/delay": "^2.0.0",
@@ -49,6 +50,7 @@
     "@types/pify": "^3.0.0",
     "@types/pretty-ms": "^3.0.0",
     "@types/request": "^2.0.7",
+    "@types/semver": "^5.5.0",
     "@types/sinon": "^4.0.0",
     "codecov": "^3.0.0",
     "gts": "^0.5.3",
@@ -76,5 +78,8 @@
       "out/test",
       "out/system-test"
     ]
+  },
+  "engines": {
+    "node": "6.12.3 - 7.0.0 || >=8.9.4"
   }
 }

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -18,6 +18,7 @@ import * as delay from 'delay';
 import * as extend from 'extend';
 import * as gcpMetadata from 'gcp-metadata';
 import * as path from 'path';
+import * as semver from 'semver';
 import {normalize} from 'path';
 import * as pify from 'pify';
 
@@ -121,17 +122,26 @@ let profiler: Profiler|undefined = undefined;
  *
  */
 export async function start(config: Config = {}): Promise<void> {
+  if (!semver.satisfies(process.version, pjson.engines.node)) {
+    logError(`Could not start profiler: node version ${process.version}` 
+        +` does not satisfies "${pjson.engines.node}"`, config);
+    return;
+  }
   let normalizedConfig: ProfilerConfig;
   try {
     normalizedConfig = await initConfig(config);
   } catch (e) {
-    const logger = new common.logger(
-        {level: common.logger.LEVELS[config.logLevel || 2], tag: pjson.name});
-    logger.error(`Could not start profiler: ${e}`);
+    logError(`Could not start profiler: ${e}`, config);
     return;
   }
   profiler = new Profiler(normalizedConfig);
   profiler.start();
+}
+
+function logError(msg: string, config: Config) {
+  const logger = new common.logger(
+    {level: common.logger.LEVELS[config.logLevel || 2], tag: pjson.name});
+  logger.error(msg);
 }
 
 

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -18,9 +18,9 @@ import * as delay from 'delay';
 import * as extend from 'extend';
 import * as gcpMetadata from 'gcp-metadata';
 import * as path from 'path';
-import * as semver from 'semver';
 import {normalize} from 'path';
 import * as pify from 'pify';
+import * as semver from 'semver';
 
 import {AuthenticationConfig, Common, ServiceConfig} from '../third_party/types/common-types';
 
@@ -123,8 +123,10 @@ let profiler: Profiler|undefined = undefined;
  */
 export async function start(config: Config = {}): Promise<void> {
   if (!semver.satisfies(process.version, pjson.engines.node)) {
-    logError(`Could not start profiler: node version ${process.version}` 
-        +` does not satisfies "${pjson.engines.node}"`, config);
+    logError(
+        `Could not start profiler: node version ${process.version}` +
+            ` does not satisfies "${pjson.engines.node}"`,
+        config);
     return;
   }
   let normalizedConfig: ProfilerConfig;
@@ -140,7 +142,7 @@ export async function start(config: Config = {}): Promise<void> {
 
 function logError(msg: string, config: Config) {
   const logger = new common.logger(
-    {level: common.logger.LEVELS[config.logLevel || 2], tag: pjson.name});
+      {level: common.logger.LEVELS[config.logLevel || 2], tag: pjson.name});
   logger.error(msg);
 }
 


### PR DESCRIPTION
This PR adds `engines` to the package.json and prevents the profiler from starting when a version of node not matching the version specified in `engines` is used.