### PR TITLE
fix: update integration test so it runs successfully.

### DIFF
--- a/testing/busybench.js
+++ b/testing/busybench.js
@@ -23,7 +23,9 @@ const startTime = Date.now();
 function benchmark(durationSeconds) {
   var buffer = new Buffer(1e4);
   for (var k = 0; k < 1e4; k++) {
-    buffer.fill(0);
+    for (var j = 0; j < buffer.length; j++) {
+      buffer[j] = 0;
+    }
   }
   if (Date.now() - startTime < 1000 * durationSeconds) {
     setImmediate(() => benchmark(durationSeconds));

--- a/testing/integration_test.go
+++ b/testing/integration_test.go
@@ -25,7 +25,7 @@ import (
 	"text/template"
 	"time"
 
-	"cloud.google.com/go/profiler/proftest"
+	"github.com/GoogleCloudPlatform/google-cloud-go/profiler/proftest"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v1"

--- a/testing/integration_test.sh
+++ b/testing/integration_test.sh
@@ -15,7 +15,7 @@ REPO=$(git config --get remote.origin.url)
 
 
 export GCLOUD_TESTS_NODEJS_PROJECT_ID="cloud-profiler-e2e"
-export GCLOUD_TESTS_NODEJS_ZONE="us-east1-a"
+export GCLOUD_TESTS_NODEJS_ZONE="us-east1-b"
 export GOOGLE_APPLICATION_CREDENTIALS="${SERVICE_KEY}"
 
 # Move test to go path.


### PR DESCRIPTION
This PR includes small changes needed to allow e2e tests to run successfully. 

Most notably, it stops using `fill()` in busybench.js -- based on profiles, it appears that `fill()` now uses a setImmediate somewhere in node 8 and node 9, so the work was no longer attributed to `benchmark()`.