### PR TITLE
chore: update gcp-metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/profiler",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -277,15 +277,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-    },
-    "axios": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
-      "requires": {
-        "follow-redirects": "1.3.0",
-        "is-buffer": "1.1.6"
-      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -1044,13 +1035,29 @@
       "dev": true
     },
     "gcp-metadata": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.5.0.tgz",
-      "integrity": "sha512-G+haBuoUrnLzzJfnAuefG2yR0TC7Pgn8iw9L7YgacbBeQYx+/QiTulmYfetj923HMz0nWNW7Q7/fmNCLFMMN4Q==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
+      "integrity": "sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==",
       "requires": {
-        "axios": "0.17.1",
+        "axios": "0.18.0",
         "extend": "3.0.1",
-        "retry-axios": "0.3.0"
+        "retry-axios": "0.3.2"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+          "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+          "requires": {
+            "follow-redirects": "1.3.0",
+            "is-buffer": "1.1.6"
+          }
+        },
+        "retry-axios": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-0.3.2.tgz",
+          "integrity": "sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ=="
+        }
       }
     },
     "get-func-name": {
@@ -1519,46 +1526,90 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "js-green-licenses": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.4.0.tgz",
-      "integrity": "sha512-LpkL/9coWxNUmJ9/jxng3uvcLK6Qso2yaz7QBjO+atwtX/xmt8MrCtbkolYdhPZl/fq5dRs7Q7BLA8Ne3DKZ2w==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.5.0.tgz",
+      "integrity": "sha512-HM/SKwAl1R0y9kkBili6GqKc31ZnjzY7JHC2uO9bAHJNRmY5c/s+2cETyaqX0kBD8gX8QVhS4dJjRtY1nAwb4w==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
-        "axios": "0.17.1",
+        "axios": "0.18.0",
         "npm-package-arg": "6.0.0",
         "package-json": "4.0.1",
         "pify": "3.0.0",
-        "spdx-correct": "2.0.4",
-        "spdx-satisfies": "0.1.3",
+        "spdx-correct": "3.0.0",
+        "spdx-satisfies": "4.0.0",
         "strip-json-comments": "2.0.1"
       },
       "dependencies": {
-        "spdx-correct": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-2.0.4.tgz",
-          "integrity": "sha512-c+4gPpt9YDhz7cHlz5UrsHzxxRi4ksclxnEEKsuGT9JdwSC+ZNmsGbYRzzgxyZaBYpcWnlu+4lPcdLKx4DOCmA==",
+        "axios": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+          "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
           "dev": true,
           "requires": {
-            "spdx-expression-parse": "2.0.2",
-            "spdx-license-ids": "2.0.1"
+            "follow-redirects": "1.3.0",
+            "is-buffer": "1.1.6"
           }
         },
-        "spdx-expression-parse": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-2.0.2.tgz",
-          "integrity": "sha512-oFxOkWCfFS0ltNp0H66gXlU4NF6bxg7RkoTYR0413t+yTY9zyj+AIWsjtN8dcVp6703ijDYBWBIARlJ7DkyP9Q==",
+        "spdx-compare": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
+          "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
           "dev": true,
           "requires": {
-            "spdx-exceptions": "2.0.0",
-            "spdx-license-ids": "2.0.1"
+            "array-find-index": "1.0.2",
+            "spdx-expression-parse": "3.0.0",
+            "spdx-ranges": "2.0.0"
+          }
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "3.0.0",
+            "spdx-license-ids": "3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "3.0.0"
           }
         },
         "spdx-license-ids": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-2.0.1.tgz",
-          "integrity": "sha1-AgF7zDU07k/+9tWNIOfT6aHDyOw=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+          "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
           "dev": true
+        },
+        "spdx-ranges": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.0.0.tgz",
+          "integrity": "sha512-AUUXLfqkwD7GlzZkXv8ePPCpPjeVWI9xJCfysL8re/uKb6H10umMnC7bFRsHmLJan4fslUtekAgpHlSgLc/7mA==",
+          "dev": true
+        },
+        "spdx-satisfies": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-4.0.0.tgz",
+          "integrity": "sha512-OcARj6U1OuVv98SVrRqgrR30sVocONtoPpnX8Xz4vXNrFVedqtbgkA+0KmQoXIQ2xjfltPPRVIMeNzKEFLWWKQ==",
+          "dev": true,
+          "requires": {
+            "spdx-compare": "1.0.0",
+            "spdx-expression-parse": "3.0.0",
+            "spdx-ranges": "2.0.0"
+          }
         }
       }
     },
@@ -4195,11 +4246,6 @@
         "signal-exit": "3.0.2"
       }
     },
-    "retry-axios": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-0.3.0.tgz",
-      "integrity": "sha512-6vOCghodB5p5N/ZOqug7A3WsT42TULZ7NErUi4lP3KtwtXgz4hE/43LWHsFuHuBfXRmOm/tjXBWAjnObrcy+yg=="
-    },
     "retry-request": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.1.tgz",
@@ -4334,16 +4380,6 @@
         "source-map": "0.6.1"
       }
     },
-    "spdx-compare": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-0.1.2.tgz",
-      "integrity": "sha1-sGrz6jSvdDfZGp9Enq8tLpPDyPs=",
-      "dev": true,
-      "requires": {
-        "spdx-expression-parse": "1.0.4",
-        "spdx-ranges": "1.0.1"
-      }
-    },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
@@ -4352,12 +4388,6 @@
       "requires": {
         "spdx-license-ids": "1.2.2"
       }
-    },
-    "spdx-exceptions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.0.0.tgz",
-      "integrity": "sha1-aoDpnx8z5ArPSX9qQwz0mWnwE6g=",
-      "dev": true
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -4370,22 +4400,6 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
-    },
-    "spdx-ranges": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-1.0.1.tgz",
-      "integrity": "sha1-D07se46kjtIC43S7iULo0Y3AET4=",
-      "dev": true
-    },
-    "spdx-satisfies": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-0.1.3.tgz",
-      "integrity": "sha1-Z6HydOYRXUquKK/kdNt2FkvhC9w=",
-      "dev": true,
-      "requires": {
-        "spdx-compare": "0.1.2",
-        "spdx-expression-parse": "1.0.4"
-      }
     },
     "split-array-stream": {
       "version": "1.0.3",
@@ -4627,9 +4641,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
       "dev": true
     },
     "unique-string": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bindings": "^1.2.1",
     "delay": "^2.0.0",
     "extend": "^3.0.1",
-    "gcp-metadata": "^0.5.0",
+    "gcp-metadata": "^0.6.1",
     "nan": "^2.8.0",
     "parse-duration": "^0.1.1",
     "pify": "^3.0.0",
@@ -61,7 +61,7 @@
     "sinon": "^4.0.1",
     "source-map-support": "^0.5.0",
     "ts-mockito": "^2.2.5",
-    "typescript": "~2.6.x"
+    "typescript": "~2.7.x"
   },
   "files": [
     "out/src",

--- a/ts/src/profilers/heap-profiler.ts
+++ b/ts/src/profilers/heap-profiler.ts
@@ -20,7 +20,7 @@ import {serializeHeapProfile} from './profile-serializer';
 const profiler = require('bindings')('sampling_heap_profiler');
 
 export class HeapProfiler {
-  private enabled: boolean;
+  private enabled = false;
 
   /**
    * @param intervalBytes - average bytes between samples.


### PR DESCRIPTION
gcp-metadata uses computed property names, so requires typescript 2.7 or greater.
fixes #136 