### PR TITLE
fix: common-types should be part of package

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "files": [
     "out/src",
+    "out/third_party/types",
     "bindings",
     "proto",
     "binding.gyp",


### PR DESCRIPTION
fixes #169 