### PR TITLE
add node in profile to track external memory

### DIFF
--- a/ts/test/profiles-for-tests.ts
+++ b/ts/test/profiles-for-tests.ts
@@ -209,15 +209,16 @@ export const v8HeapProfile = {
 
 const heapLines = [
   {functionId: 1, line: 1}, {functionId: 2, line: 5}, {functionId: 3, line: 10},
-  {functionId: 4, line: 8}
+  {functionId: 4, line: 8}, {functionId: 5}
 ];
 
 const heapFunctions = [
   new perftools.profiles.Function({id: 1, name: 5, systemName: 5, filename: 5}),
   new perftools.profiles.Function({id: 2, name: 6, systemName: 6, filename: 7}),
   new perftools.profiles.Function({id: 3, name: 8, systemName: 8, filename: 7}),
+  new perftools.profiles.Function({id: 4, name: 9, systemName: 9, filename: 7}),
   new perftools.profiles.Function(
-      {id: 4, name: 9, systemName: 9, filename: 7})
+      {id: 5, name: 10, systemName: 10, filename: 0})
 ];
 
 const heapLocations = [
@@ -225,6 +226,7 @@ const heapLocations = [
   new perftools.profiles.Location({line: [heapLines[1]], id: 2}),
   new perftools.profiles.Location({line: [heapLines[2]], id: 3}),
   new perftools.profiles.Location({line: [heapLines[3]], id: 4}),
+  new perftools.profiles.Location({line: [heapLines[4]], id: 5}),
 ];
 
 export const heapProfile: perftools.profiles.IProfile = {
@@ -241,20 +243,14 @@ export const heapProfile: perftools.profiles.IProfile = {
         {locationId: [3, 2, 1], value: [15, 15 * 72], label: []}),
     new perftools.profiles.Sample(
         {locationId: [4, 2, 1], value: [5, 5 * 1024], label: []}),
+    new perftools.profiles.Sample(
+        {locationId: [5], value: [1, 1024], label: []}),
   ],
   location: heapLocations,
   function: heapFunctions,
   stringTable: [
-    '',
-    'objects',
-    'count',
-    'space',
-    'bytes',
-    'main',
-    'function1',
-    'script1',
-    'function3',
-    'function2',
+    '', 'objects', 'count', 'space', 'bytes', 'main', 'function1', 'script1',
+    'function3', 'function2', '(external)'
   ],
   timeNanos: 0,
   periodType: new perftools.profiles.ValueType({type: 3, unit: 4}),
@@ -289,14 +285,19 @@ export const v8AnonymousFunctionHeapProfile = {
 
 const anonymousFunctionHeapLines = [
   {functionId: 1, line: 1},
+  {functionId: 2},
 ];
 
 const anonymousFunctionHeapFunctions = [
   new perftools.profiles.Function({id: 1, name: 5, systemName: 5, filename: 6}),
+  new perftools.profiles.Function({id: 2, name: 7, systemName: 7, filename: 0}),
 ];
 
 const anonymousFunctionHeapLocations = [
-  new perftools.profiles.Location({line: [heapLines[0]], id: 1}),
+  new perftools.profiles.Location(
+      {line: [anonymousFunctionHeapLines[0]], id: 1}),
+  new perftools.profiles.Location(
+      {line: [anonymousFunctionHeapLines[1]], id: 2}),
 ];
 
 export const anonymousFunctionHeapProfile: perftools.profiles.IProfile = {
@@ -306,17 +307,14 @@ export const anonymousFunctionHeapProfile: perftools.profiles.IProfile = {
   ],
   sample: [
     new perftools.profiles.Sample({locationId: [1], value: [1, 5], label: []}),
+    new perftools.profiles.Sample(
+        {locationId: [2], value: [1, 1024], label: []}),
   ],
   location: anonymousFunctionHeapLocations,
   function: anonymousFunctionHeapFunctions,
   stringTable: [
-    '',
-    'objects',
-    'count',
-    'space',
-    'bytes',
-    '(anonymous)',
-    'main',
+    '', 'objects', 'count', 'space', 'bytes', '(anonymous)', 'main',
+    '(external)'
   ],
   timeNanos: 0,
   periodType: new perftools.profiles.ValueType({type: 3, unit: 4}),

--- a/ts/test/test-heap-profiler.ts
+++ b/ts/test/test-heap-profiler.ts
@@ -30,12 +30,19 @@ describe('HeapProfiler', () => {
   let stopStub: sinon.SinonStub;
   let profileStub: sinon.SinonStub;
   let dateStub: sinon.SinonStub;
+  let memoryUsageStub: sinon.SinonStub;
   beforeEach(() => {
     startStub = sinon.stub(v8HeapProfiler, 'startSamplingHeapProfiler');
     stopStub = sinon.stub(v8HeapProfiler, 'stopSamplingHeapProfiler');
     profileStub = sinon.stub(v8HeapProfiler, 'getAllocationProfile')
                       .returns(v8HeapProfile);
     dateStub = sinon.stub(Date, 'now').returns(0);
+    memoryUsageStub = sinon.stub(process, 'memoryUsage').returns({
+      external: 1024,
+      rss: 2048,
+      heapTotal: 4096,
+      heapUse: 2048,
+    });
   });
 
   afterEach(() => {
@@ -44,6 +51,7 @@ describe('HeapProfiler', () => {
     stopStub.restore();
     profileStub.restore();
     dateStub.restore();
+    memoryUsageStub.restore();
   });
   describe('profile', () => {
     it('should return a profile equal to the expected profile', async () => {

--- a/ts/test/test-profile-serializer.ts
+++ b/ts/test/test-profile-serializer.ts
@@ -24,8 +24,16 @@ const assert = require('assert');
 
 describe('serializeTimeProfile', () => {
   let dateStub: sinon.SinonStub;
+  let memoryUsageStub: sinon.SinonStub;
+
   before(() => {
     dateStub = sinon.stub(Date, 'now').returns(0);
+    memoryUsageStub = sinon.stub(process, 'memoryUsage').returns({
+      external: 1024,
+      rss: 2048,
+      heapTotal: 4096,
+      heapUse: 2048,
+    });
   });
   after(() => {
     dateStub.restore();


### PR DESCRIPTION
Fixes #157 

Testing:

Ran this script:
```
const profiler = require('./out/src/index.js')
profiler.start({
	projectId: 'nolanmar-test',
	logLevel: 5,
	serviceContext: {
		service: 'test-external',
		version: '3'
  },
  // baseApiUrl: 'https://test-cloudprofiler.sandbox.googleapis.com/v2',
});

const startTime = Date.now();
const testArr = [];
const testBuf = [];

/**
 * Fills several arrays, then calls itself with setImmediate.
 * It continues to do this until durationSeconds after the startTime.
 */
function busyLoop(durationSeconds) {
  for (let i = 0; i < testBuf.length; i++) {
    for (let j = 0; j < testBuf[i].length; j++) {
      testBuf[i][j] = Math.sqrt(j * testBuf[i][j]);
    }
  }
  if (Date.now() - startTime < 1000 * durationSeconds) {
    setTimeout(() => busyLoop(durationSeconds), 5);
  }
}

function benchmark(durationSeconds) {
  // Allocate 16 MiB in 64 KiB chunks.
  for (let i = 0; i < 16*16; i++) {
    testBuf[i] = new Buffer(64 * 1024);
  }

  busyLoop(durationSeconds)
}

const durationSeconds = process.argv.length > 2 ? process.argv[2] : 600; 
setTimeout(()=>benchmark(durationSeconds), 1000);
```

This profile, with 16MiB in external, was uploaded:
![image](https://user-images.githubusercontent.com/14046562/39658379-5dfffc4e-4fc8-11e8-8f6b-5775f80e4eaf.png)
