### PR TITLE
fix: parse the response body message to determine retry backoff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,9 +122,9 @@
       }
     },
     "@google-cloud/common": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.20.0.tgz",
-      "integrity": "sha512-OCeDhpt+Qr90GxMFi54302Maf45Nux8ymF/jXgpPNElJUsjTmSN+Vzg3WmfAY+TYG9MDL2VufjjwlM4XrcNYcw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.20.3.tgz",
+      "integrity": "sha512-jt8/R4EqDTQccv5WA9AEaS65llM5+mlxsuWu57G5Os8HTIpgPbcsOVMUeIvmTrBuPUYSoRIMW8d/pvv/95n0+g==",
       "requires": {
         "@types/duplexify": "^3.5.0",
         "@types/request": "^2.47.0",
@@ -137,21 +137,10 @@
         "is": "^3.2.1",
         "pify": "^3.0.0",
         "request": "^2.87.0",
-        "retry-request": "^3.3.1",
+        "retry-request": "^4.0.0",
         "split-array-stream": "^2.0.0",
         "stream-events": "^1.0.4",
         "through2": "^2.0.3"
-      },
-      "dependencies": {
-        "retry-request": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.2.tgz",
-          "integrity": "sha512-WIiGp37XXDC6e7ku3LFoi7LCL/Gs9luGeeqvbPRb+Zl6OQMw4RCRfSaW+aLfE6lhz1R941UavE6Svl3Dm5xGIQ==",
-          "requires": {
-            "request": "^2.81.0",
-            "through2": "^2.0.0"
-          }
-        }
       }
     },
     "@protobufjs/aspromise": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@google-cloud/common": "^0.20.0",
+    "@google-cloud/common": "^0.20.3",
     "bindings": "^1.2.1",
     "delay": "^3.0.0",
     "extend": "^3.0.1",

--- a/ts/src/profiler.ts
+++ b/ts/src/profiler.ts
@@ -81,16 +81,16 @@ function getServerResponseBackoff(response: http.IncomingMessage): number|
     undefined {
   // tslint:disable-next-line: no-any
   const body = (response as any).body;
-  if (body && body.error && body.error.details &&
-      Array.isArray(body.error.details)) {
-    for (const item of body.error.details) {
-      if (typeof item === 'object' && item.retryDelay &&
-          typeof item.retryDelay === 'string') {
-        const backoffMillis = parseDuration(item.retryDelay);
-        if (backoffMillis > 0) {
-          return backoffMillis;
-        }
-      }
+
+  // The response currently does not have field containing the retry duration.
+  // As a work-around, response body's message is parsed to get the backoff 
+  // duration.
+  // TODO: Remove this work-around and get the retry delay from
+  // body.error.details.
+  if (body && body.message && typeof body.message === 'string') {
+    const backoffMillis = parseDuration(body.message);
+    if (backoffMillis > 0) {
+      return backoffMillis;
     }
   }
   return undefined;

--- a/ts/src/profiler.ts
+++ b/ts/src/profiler.ts
@@ -73,9 +73,6 @@ export interface RequestProfile {
   labels?: {instance?: string};
 }
 
-const BACKOFF_MSG_PAT =
-    /action throttled, backoff for ((?:([0-9]+)h)?(?:([0-9]+)m)?([0-9.]+)s)$/;
-
 /**
  * @return number indicated by backoff if the response indicates a backoff and
  * that backoff is greater than 0. Otherwise returns undefined.
@@ -102,10 +99,13 @@ function getServerResponseBackoff(response: http.IncomingMessage): number|
  *
  * Public for testing.
  */
-export function parseBackoffDuration(backoffStr: string): number|undefined {
-  const found = backoffStr.match(BACKOFF_MSG_PAT);
-  if (found && found.length >= 2 && typeof found[1] === 'string') {
-    const backoffMillis = parseDuration(found[1]);
+export function parseBackoffDuration(backoffMessage: string): number|undefined {
+  const backoffMessageRegex =
+      /action throttled, backoff for ((?:([0-9]+)h)?(?:([0-9]+)m)?([0-9.]+)s)$/;
+  const [, duration] =
+      backoffMessageRegex.exec(backoffMessage) || [undefined, undefined];
+  if (duration) {
+    const backoffMillis = parseDuration(duration);
     if (backoffMillis > 0) {
       return backoffMillis;
     }

--- a/ts/test/test-profiler.ts
+++ b/ts/test/test-profiler.ts
@@ -25,7 +25,7 @@ import * as zlib from 'zlib';
 
 import {perftools} from '../../proto/profile';
 import {ProfilerConfig} from '../src/config';
-import {Profiler, Retryer} from '../src/profiler';
+import {parseBackoffDuration, Profiler, Retryer} from '../src/profiler';
 import * as heapProfiler from '../src/profilers/heap-profiler';
 import {TimeProfiler} from '../src/profilers/time-profiler';
 
@@ -842,7 +842,7 @@ describe('Profiler', () => {
                  .onCall(0)
                  .callsArgWith(1, undefined, undefined, {
                    statusCode: 409,
-                   body: {message: 'action throttled, backoff for 1000h'},
+                   body: {message: 'action throttled, backoff for 1000h0s'},
                  });
          const profiler = new Profiler(testConfig);
          profiler.timeProfiler = instance(mockTimeProfiler);
@@ -873,5 +873,43 @@ describe('Profiler', () => {
          const delayMillis = await profiler.collectProfile();
          assert.equal(0, delayMillis);
        });
+  });
+  describe('parseBackoffDuration', () => {
+    it('should return undefined when no duration specified', () => {
+      assert.equal(undefined, parseBackoffDuration(''));
+    });
+    it('should parse backoff with minutes and seconds specified', () => {
+      assert.equal(
+          62000, parseBackoffDuration('action throttled, backoff for 1m2s'));
+    });
+    it('should parse backoff with fraction of second', () => {
+      assert.equal(
+          2500, parseBackoffDuration('action throttled, backoff for 2.5s'));
+    });
+    it('should parse backoff with minutes and seconds, including fraction of second',
+       () => {
+         assert.equal(
+             62500,
+             parseBackoffDuration('action throttled, backoff for 1m2.5s'));
+       });
+    it('should parse backoff with hours and seconds', () => {
+      assert.equal(
+          3602500,
+          parseBackoffDuration('action throttled, backoff for 1h2.5s'));
+    });
+    it('should parse backoff with hours, minutes, and seconds', () => {
+      assert.equal(
+          3662500,
+          parseBackoffDuration('action throttled, backoff for 1h1m2.5s'));
+    });
+    it('should parse return undefined for unexpected backoff time string format',
+       () => {
+         assert.equal(
+             undefined,
+             parseBackoffDuration('action throttled, backoff for  1m2+s'));
+       });
+    it('should parse return undefined for unexpected string format', () => {
+      assert.equal(undefined, parseBackoffDuration('time 1m2s'));
+    });
   });
 });

--- a/ts/test/test-profiler.ts
+++ b/ts/test/test-profiler.ts
@@ -637,7 +637,9 @@ describe('Profiler', () => {
                            .onCall(0)
                            .callsArgWith(1, undefined, undefined, {
                              statusCode: 409,
-                             body: {error: {details: [{retryDelay: '50s'}]}}
+                             body: {
+                               message: 'action throttled, backoff for 50s',
+                             }
                            });
 
          const profiler = new Profiler(testConfig);
@@ -792,12 +794,13 @@ describe('Profiler', () => {
            duration: '10s',
            labels: {instance: config.instance}
          };
-         requestStub = sinon.stub(common.ServiceObject.prototype, 'request')
-                           .onCall(0)
-                           .callsArgWith(1, undefined, undefined, {
-                             statusCode: 409,
-                             body: {error: {details: [{retryDelay: '50s'}]}}
-                           });
+         requestStub =
+             sinon.stub(common.ServiceObject.prototype, 'request')
+                 .onCall(0)
+                 .callsArgWith(1, undefined, undefined, {
+                   statusCode: 409,
+                   body: {message: 'action throttled, backoff for 50s'}
+                 });
          const profiler = new Profiler(testConfig);
          profiler.timeProfiler = instance(mockTimeProfiler);
          const delayMillis = await profiler.collectProfile();
@@ -817,7 +820,7 @@ describe('Profiler', () => {
                            .onCall(0)
                            .callsArgWith(1, undefined, undefined, {
                              statusCode: 409,
-                             body: {error: {details: [{retryDelay: ''}]}}
+                             body: {message: 'some message'},
                            });
          const profiler = new Profiler(testConfig);
          profiler.timeProfiler = instance(mockTimeProfiler);
@@ -825,7 +828,7 @@ describe('Profiler', () => {
          assert.equal(500, delayMillis);
        });
     it('should return backoff limit, when server specified backoff is greater' +
-           'then backoff limit',
+           ' then backoff limit',
        async () => {
          const config = extend(true, {}, testConfig);
          const requestProfileResponseBody = {
@@ -839,7 +842,7 @@ describe('Profiler', () => {
                  .onCall(0)
                  .callsArgWith(1, undefined, undefined, {
                    statusCode: 409,
-                   body: {error: {details: [{retryDelay: '1000h'}]}}
+                   body: {message: 'action throttled, backoff for 1000h'},
                  });
          const profiler = new Profiler(testConfig);
          profiler.timeProfiler = instance(mockTimeProfiler);


### PR DESCRIPTION
This fixes #245.
