### PR TITLE
chore: use --trace-warnings flag when calling node in e2e test

### DIFF
--- a/testing/integration_test.go
+++ b/testing/integration_test.go
@@ -98,7 +98,7 @@ cd "$TESTDIR"
 retry npm install "$PROFILER" >/dev/null
 
 # Run benchmark with agent
-GCLOUD_PROFILER_LOGLEVEL=5 GAE_SERVICE={{.Service}} node --require @google-cloud/profiler busybench.js 600
+GCLOUD_PROFILER_LOGLEVEL=5 GAE_SERVICE={{.Service}} node --trace-warnings --require @google-cloud/profiler busybench.js 600
 
 # Indicate to test that script has finished running
 echo "busybench finished profiling"


### PR DESCRIPTION
Fixes #247 