### PR TITLE
chore: generate package-lock.json in npm-audit presubmit check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,9 @@ npmaudit: &npmaudit
   steps:
     - checkout
     - run:
+        name: Create package-lock.json.
+        command: npm i --package-lock-only
+    - run:
         name: Run npm security audit.
         command: npm audit
 


### PR DESCRIPTION
Since #267, the npm audit check has been failing since there is not package-lock.json.
The PR modifies the npm audit presubmit test so a package-lock.json is generated before npm audit is run.