### PR TITLE
chore: use console-log-level for logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@google-cloud/common": "^0.20.3",
     "bindings": "^1.2.1",
+    "console-log-level": "^1.4.0",
     "delay": "^3.0.0",
     "extend": "^3.0.1",
     "gcp-metadata": "^0.7.0",
@@ -41,6 +42,7 @@
     "semver": "^5.5.0"
   },
   "devDependencies": {
+    "@types/console-log-level": "^1.4.0",
     "@types/delay": "^2.0.0",
     "@types/extend": "^3.0.0",
     "@types/long": "^4.0.0",

--- a/ts/src/profiler.ts
+++ b/ts/src/profiler.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import {Logger, Service, ServiceObject, util} from '@google-cloud/common';
+import {Service, ServiceObject, util} from '@google-cloud/common';
+import * as consoleLogLevel from 'console-log-level';
 import * as http from 'http';
 import * as path from 'path';
 import * as pify from 'pify';
@@ -24,6 +25,7 @@ import * as zlib from 'zlib';
 import {perftools} from '../../proto/profile';
 
 import {ProfilerConfig} from './config';
+import {logLevelToName} from './index';
 import * as heapProfiler from './profilers/heap-profiler';
 import {TimeProfiler} from './profilers/time-profiler';
 
@@ -232,7 +234,7 @@ function responseToProfileOrError(
  * profiles can be collected.
  */
 export class Profiler extends ServiceObject {
-  private logger: Logger;
+  private logger: consoleLogLevel.Logger;
   private profileLabels: {instance?: string};
   private deployment: Deployment;
   private profileTypes: string[];
@@ -252,8 +254,11 @@ export class Profiler extends ServiceObject {
     super({parent: new Service(serviceConfig, config), baseUrl: '/'});
     this.config = config;
 
-    this.logger = new Logger(
-        {level: Logger.LEVELS[config.logLevel as number], tag: pjson.name});
+    this.logger = consoleLogLevel({
+      stderr: true,
+      prefix: pjson.name,
+      level: logLevelToName(this.config.logLevel)
+    });
 
     const labels: {zone?: string,
                    version?: string, language: string} = {language: 'nodejs'};


### PR DESCRIPTION
This is necessary to upgrade `@google-cloud/common` to 0.21.0.

Logging was a part of common previously, but has been moved (more details on https://github.com/googleapis/nodejs-common/issues/204) 