### PR TITLE
fix: modify so tests pass when GCLOUD_PROJECT specified

### DIFF
--- a/ts/test/test-init-config.ts
+++ b/ts/test/test-init-config.ts
@@ -88,6 +88,7 @@ describe('createProfiler', () => {
   let defaultConfig: GlobalConfig;
 
   before(async () => {
+    process.env = {};
     defaultConfig = await common.util.normalizeArguments(
         null, extend({}, internalConfigParams as GlobalConfig));
     startStub = sinon.stub(v8HeapProfiler, 'startSamplingHeapProfiler');


### PR DESCRIPTION
Fixes #273 