### PR TITLE
fix: use fixed minor version of delay

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@google-cloud/common": "^0.20.3",
     "bindings": "^1.2.1",
     "console-log-level": "^1.4.0",
-    "delay": "^3.0.0",
+    "delay": "~3.0.0",
     "extend": "^3.0.1",
     "gcp-metadata": "^0.7.0",
     "nan": "^2.8.0",


### PR DESCRIPTION
Fixes #276.

After this, it will still be necessary to upgrade the version delay which is being used.