### PR TITLE
chore(package): upgrade to delay@3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@google-cloud/common": "^0.20.3",
     "bindings": "^1.2.1",
     "console-log-level": "^1.4.0",
-    "delay": "~3.0.0",
+    "delay": "^3.1.0",
     "extend": "^3.0.1",
     "gcp-metadata": "^0.7.0",
     "nan": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "devDependencies": {
     "@types/console-log-level": "^1.4.0",
-    "@types/delay": "^2.0.0",
     "@types/extend": "^3.0.0",
     "@types/long": "^4.0.0",
     "@types/mocha": "^5.0.0",

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -16,7 +16,7 @@
 
 import {util} from '@google-cloud/common';
 import * as consoleLogLevel from 'console-log-level';
-import * as delay from 'delay';
+import delay from 'delay';
 import * as extend from 'extend';
 import * as fs from 'fs';
 import * as gcpMetadata from 'gcp-metadata';

--- a/ts/src/profilers/time-profiler.ts
+++ b/ts/src/profilers/time-profiler.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as delay from 'delay';
+import delay from 'delay';
 
 import {perftools} from '../../../proto/profile';
 import {serializeTimeProfile} from './profile-serializer';

--- a/ts/system-test/test-start.ts
+++ b/ts/system-test/test-start.ts
@@ -15,7 +15,7 @@
  */
 
 import * as assert from 'assert';
-import * as delay from 'delay';
+import delay from 'delay';
 import * as nock from 'nock';
 import * as pify from 'pify';
 import * as zlib from 'zlib';

--- a/ts/test/test-heap-profiler.ts
+++ b/ts/test/test-heap-profiler.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as delay from 'delay';
+import delay from 'delay';
 import * as sinon from 'sinon';
 
 import {perftools} from '../../proto/profile';

--- a/ts/test/test-time-profiler.ts
+++ b/ts/test/test-time-profiler.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as delay from 'delay';
+import delay from 'delay';
 import * as sinon from 'sinon';
 
 import {perftools} from '../../proto/profile';


### PR DESCRIPTION
The package started shipping types as part of the official package.
These are breaking changes w.r.t previous `@types/delay` types. We need
to import the module differently now for things to work correctly.