### PR TITLE
fix(deps): update dependency @google-cloud/common to ^0.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@google-cloud/common": "^0.20.3",
+    "@google-cloud/common": "^0.23.0",
     "bindings": "^1.2.1",
     "console-log-level": "^1.4.0",
     "delay": "~3.0.0",
@@ -37,6 +37,7 @@
     "pify": "^4.0.0",
     "pretty-ms": "^3.1.0",
     "protobufjs": "~6.8.6",
+    "request": "^2.88.0",
     "semver": "^5.5.0"
   },
   "devDependencies": {
@@ -49,7 +50,7 @@
     "@types/node": "^10.0.3",
     "@types/pify": "^3.0.0",
     "@types/pretty-ms": "^3.0.0",
-    "@types/request": "^2.0.7",
+    "@types/request": "^2.47.1",
     "@types/semver": "^5.5.0",
     "@types/sinon": "^5.0.1",
     "codecov": "^3.0.0",

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -17,7 +17,6 @@
 import {GoogleAuthOptions} from '@google-cloud/common';
 
 const parseDuration: (str: string) => number = require('parse-duration');
-const extend = require('extend');
 
 // Configuration for Profiler.
 export interface Config extends GoogleAuthOptions {

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 
-import {util} from '@google-cloud/common';
 import * as consoleLogLevel from 'console-log-level';
 import * as delay from 'delay';
 import * as extend from 'extend';
 import * as fs from 'fs';
 import * as gcpMetadata from 'gcp-metadata';
-import * as path from 'path';
-import {normalize} from 'path';
-import * as pify from 'pify';
 import * as semver from 'semver';
 import {SemVer} from 'semver';
 

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -53,8 +53,6 @@ function hasService(config: Config):
  * Throws error if value that must be set cannot be initialized.
  */
 function initConfigLocal(config: Config): ProfilerConfig {
-  config = util.normalizeArguments(null, config);
-
   const envConfig: Config = {
     projectId: process.env.GCLOUD_PROJECT,
     serviceContext: {

--- a/ts/src/profiler.ts
+++ b/ts/src/profiler.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import {Service, ServiceConfig, ServiceObject, util} from '@google-cloud/common';
+import {Service, ServiceConfig, ServiceObject} from '@google-cloud/common';
 import * as consoleLogLevel from 'console-log-level';
 import * as http from 'http';
-import * as path from 'path';
 import * as pify from 'pify';
 import * as msToStr from 'pretty-ms';
 import * as request from 'request';

--- a/ts/src/profiler.ts
+++ b/ts/src/profiler.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import {Service, ServiceObject, util} from '@google-cloud/common';
+import {Service, ServiceConfig, ServiceObject, util} from '@google-cloud/common';
 import * as consoleLogLevel from 'console-log-level';
 import * as http from 'http';
 import * as path from 'path';
 import * as pify from 'pify';
 import * as msToStr from 'pretty-ms';
+import * as request from 'request';
 import * as zlib from 'zlib';
 
 import {perftools} from '../../proto/profile';
@@ -245,13 +246,18 @@ export class Profiler extends ServiceObject {
   config: ProfilerConfig;
 
   constructor(config: ProfilerConfig) {
-    config = util.normalizeArguments(null, config) as ProfilerConfig;
-    const serviceConfig = {
+    config = config || {} as ProfilerConfig;
+    const serviceConfig: ServiceConfig = {
       baseUrl: config.baseApiUrl,
       scopes: [SCOPE],
       packageJson: pjson,
+      requestModule: request,
     };
-    super({parent: new Service(serviceConfig, config), baseUrl: '/'});
+    super({
+      parent: new Service(serviceConfig, config),
+      baseUrl: '/',
+      requestModule: request
+    });
     this.config = config;
 
     this.logger = consoleLogLevel({

--- a/ts/src/profilers/heap-profiler.ts
+++ b/ts/src/profilers/heap-profiler.ts
@@ -15,7 +15,6 @@
  */
 
 import {perftools} from '../../../proto/profile';
-import {defaultConfig} from '../config';
 import {AllocationProfileNode} from '../v8-types';
 
 import {serializeHeapProfile} from './profile-serializer';

--- a/ts/system-test/test-start.ts
+++ b/ts/system-test/test-start.ts
@@ -21,8 +21,7 @@ import * as pify from 'pify';
 import * as zlib from 'zlib';
 
 import {perftools} from '../../proto/profile';
-import {Config} from '../src/config';
-import {Profiler, RequestProfile} from '../src/profiler';
+import {RequestProfile} from '../src/profiler';
 
 const API = 'https://cloudprofiler.googleapis.com/v2';
 let savedEnv: {};

--- a/ts/test/profiles-for-tests.ts
+++ b/ts/test/profiles-for-tests.ts
@@ -15,7 +15,7 @@
  */
 
 import {perftools} from '../../proto/profile';
-import {TimeProfile, TimeProfileNode} from '../src/v8-types';
+import {TimeProfile} from '../src/v8-types';
 
 const timeLeaf1 = {
   name: 'function1',

--- a/ts/test/test-heap-profiler.ts
+++ b/ts/test/test-heap-profiler.ts
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-import * as delay from 'delay';
 import * as sinon from 'sinon';
 
-import {perftools} from '../../proto/profile';
 import * as heapProfiler from '../src/profilers/heap-profiler';
 
 import {heapProfileExcludePath, heapProfileIncludePath, heapProfileWithExternal, v8HeapProfile, v8HeapWithPathProfile} from './profiles-for-tests';

--- a/ts/test/test-init-config.ts
+++ b/ts/test/test-init-config.ts
@@ -15,11 +15,9 @@
  */
 
 import * as assert from 'assert';
-import * as extend from 'extend';
 import * as gcpMetadata from 'gcp-metadata';
 import * as sinon from 'sinon';
 
-import {ProfilerConfig} from '../src/config';
 import {createProfiler, nodeVersionOkay} from '../src/index';
 import {Profiler} from '../src/profiler';
 import * as heapProfiler from '../src/profilers/heap-profiler';

--- a/ts/test/test-init-config.ts
+++ b/ts/test/test-init-config.ts
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-import * as common from '@google-cloud/common';
-import {GlobalConfig} from '@google-cloud/common/build/src/util';
 import * as assert from 'assert';
 import * as extend from 'extend';
 import * as gcpMetadata from 'gcp-metadata';
 import * as sinon from 'sinon';
 
+import {ProfilerConfig} from '../src/config';
 import {createProfiler, nodeVersionOkay} from '../src/index';
 import {Profiler} from '../src/profiler';
 import * as heapProfiler from '../src/profilers/heap-profiler';
@@ -85,12 +84,11 @@ describe('createProfiler', () => {
     localLogPeriodMillis: 10000,
     baseApiUrl: 'https://cloudprofiler.googleapis.com/v2',
   };
-  let defaultConfig: GlobalConfig;
+  let defaultConfig: {};
 
   before(async () => {
     process.env = {};
-    defaultConfig = await common.util.normalizeArguments(
-        null, extend({}, internalConfigParams as GlobalConfig));
+    defaultConfig = internalConfigParams || {};
     startStub = sinon.stub(v8HeapProfiler, 'startSamplingHeapProfiler');
     savedEnv = process.env;
   });

--- a/ts/test/test-profiler.ts
+++ b/ts/test/test-profiler.ts
@@ -20,7 +20,7 @@ import * as extend from 'extend';
 import * as nock from 'nock';
 import * as pify from 'pify';
 import * as sinon from 'sinon';
-import {instance, mock, reset, verify, when} from 'ts-mockito';
+import {instance, mock, reset, when} from 'ts-mockito';
 import * as zlib from 'zlib';
 
 import {perftools} from '../../proto/profile';


### PR DESCRIPTION
Breaking changes in common: common was split in multiple modules, HTTP
dependency must be passed in by client library.

Fixes: https://github.com/googleapis/nodejs-common/issues/204
Fixes: https://github.com/GoogleCloudPlatform/cloud-profiler-nodejs/pull/266