### PR TITLE
feat: use smaller HTTP dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "pify": "^4.0.0",
     "pretty-ms": "^3.1.0",
     "protobufjs": "~6.8.6",
-    "request": "^2.88.0",
-    "semver": "^5.5.0"
+    "semver": "^5.5.0",
+    "teeny-request": "^3.3.0"
   },
   "devDependencies": {
     "@types/console-log-level": "^1.4.0",

--- a/ts/src/profiler.ts
+++ b/ts/src/profiler.ts
@@ -19,7 +19,7 @@ import * as consoleLogLevel from 'console-log-level';
 import * as http from 'http';
 import * as pify from 'pify';
 import * as msToStr from 'pretty-ms';
-import * as request from 'request';
+import {teenyRequest as request} from 'teeny-request';
 import * as zlib from 'zlib';
 
 import {perftools} from '../../proto/profile';
@@ -250,12 +250,14 @@ export class Profiler extends ServiceObject {
       baseUrl: config.baseApiUrl,
       scopes: [SCOPE],
       packageJson: pjson,
-      requestModule: request,
+      // tslint:disable-next-line: no-any
+      requestModule: request as any,
     };
     super({
       parent: new Service(serviceConfig, config),
       baseUrl: '/',
-      requestModule: request
+      // tslint:disable-next-line: no-any
+      requestModule: request as any
     });
     this.config = config;
 

--- a/ts/system-test/test-start.ts
+++ b/ts/system-test/test-start.ts
@@ -70,6 +70,9 @@ before(async () => {
       .persist()
       .patch('/projects/X/test-projectId')
       .reply(200, (request: RequestProfile, body: RequestProfile) => {
+        if (typeof body === 'string') {
+          body = JSON.parse(body);
+        }
         tempUploadedProfiles.push(body);
       });
   nock('https://www.googleapis.com')
@@ -93,12 +96,12 @@ before(async () => {
   // copy over currently uploaded profiles, so all tests look at same profiles.
   uploadedProfiles = tempUploadedProfiles.slice();
 
-  // Restore environment vairables and mocks.
+  // Restore environment variables and mocks.
   process.env = savedEnv;
 });
 
 
-// Restore environment vairables after tests.
+// Restore environment variables after tests.
 // nock not restored, since profiles still being uploaded.
 after(() => {
   process.env = savedEnv;


### PR DESCRIPTION
Use teeny-request instead of large `request` dependency. According to
[require-so-slow](https://www.npmjs.com/package/require-so-slow),
load time improves from 1500 ms to 600 ms.

Before with `request`:
![screen shot 2018-08-23 at 4 04 23 pm](https://user-images.githubusercontent.com/101553/44549225-729b2e80-a6ee-11e8-9196-0c8228387e65.png)

After with `teeny-request`:
![screen shot 2018-08-23 at 4 04 11 pm](https://user-images.githubusercontent.com/101553/44549226-729b2e80-a6ee-11e8-87a1-d34033b4b614.png)
