### PR TITLE
chore: simplify e2e test npm output

### DIFF
--- a/system-test/integration_test.go
+++ b/system-test/integration_test.go
@@ -64,7 +64,7 @@ const startupTemplate = `
 {{ define "setup"}}
 
 npm_install() {
-	timeout 60 npm install "${@}"
+	timeout 60 npm install --quiet --no-color --no-progress "${@}"
 }
 
 # Install git
@@ -90,7 +90,7 @@ retry git fetch origin {{if .PR}}pull/{{.PR}}/head{{else}}{{.Branch}}{{end}}:pul
 git checkout pull_branch
 git reset --hard {{.Commit}}
 
-retry npm_install --nodedir="$NODEDIR" &>/dev/ttyS2
+retry npm_install --nodedir="$NODEDIR"
 
 npm run compile 
 npm pack --nodedir="$NODEDIR" >/dev/null
@@ -102,8 +102,8 @@ mkdir -p "$TESTDIR"
 cp -r "system-test/busybench" "$TESTDIR"
 cd "$TESTDIR/busybench"
 
-retry npm_install node-pre-gyp &>/dev/ttyS2
-retry npm_install --nodedir="$NODEDIR" "$PROFILER" typescript gts &>/dev/ttyS2
+retry npm_install node-pre-gyp
+retry npm_install --nodedir="$NODEDIR" "$PROFILER" typescript gts
 
 npm run compile
 {{- end }}


### PR DESCRIPTION
This change will simplify output logged by npm install, and switches to logging that output to the serial port which the E2E test's logs captures.
