### PR TITLE
chore: clean npm cache on package installations

### DIFF
--- a/system-test/integration_test.go
+++ b/system-test/integration_test.go
@@ -64,6 +64,7 @@ const startupTemplate = `
 {{ define "setup"}}
 
 npm_install() {
+	npm cache clean --force # Avoid persistent errors on rare cache corruptions.
 	timeout 60 npm install --quiet --no-color --no-progress "${@}"
 }
 


### PR DESCRIPTION
This should avoid persistent errors in case of rare npm cache corruptions.
Something like https://github.com/immerjs/immer/issues/546.