### PR TITLE
chore: rename Kokoro integration test

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -28,7 +28,7 @@ branchProtectionRules:
   requiresStrictStatusChecks: true
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
-    - "Kokoro CI"
+    - "Kokoro integration test"
     - "ci/kokoro: Samples test"
     - "ci/kokoro: System test"
     - "cla/google"


### PR DESCRIPTION
I renamed the integration test when updating the branch it runs against; updating the list of required checks to match.
