### PR TITLE
fix: workaround certificate expiration issue in integration tests

### DIFF
--- a/system-test/integration_test.sh
+++ b/system-test/integration_test.sh
@@ -14,6 +14,13 @@ set -eo pipefail
 # Display commands being run.
 set -x
 
+# Remove expired certificate; otherwise `go get` may fail.
+# See https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/
+# for more context.
+sudo apt-get install -y ca-certificates
+sudo rm -f /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt
+sudo update-ca-certificates
+
 cd $(dirname $0)/..
 
 SERVICE_KEY="${KOKORO_KEYSTORE_DIR}/72935_cloud-profiler-e2e-service-account-key"


### PR DESCRIPTION
Let's Encrypt CA certification expiration is causing integration tests to fail internally.
This commit works around this problem by removing the problematic certificate.

Context: https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/
