### PR TITLE
chore: update current owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs @googleapis/api-profiler
+*     @googleapis/yoshi-nodejs @googleapis/api-logging
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,8 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 
-# The yoshi-nodejs and cdpe-ops teams are the default owners for the nodejs profiler repository.
-*     @googleapis/yoshi-nodejs @googleapis/api-logging
+# The yoshi-nodejs team is the default owner for nodejs repositories.
+*     @googleapis/yoshi-nodejs @googleapis/api-profiler
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,8 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 
-# The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs @googleapis/api-profiler
+# The yoshi-nodejs and cdpe-ops teams are the default owners for the nodejs profiler repository.
+*     @googleapis/yoshi-nodejs @googleapis/api-logging
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,5 +9,5 @@
   "repo": "googleapis/cloud-profiler-nodejs",
   "distribution_name": "@google-cloud/profiler",
   "api_id": "cloudprofiler.googleapis.com",
-  "codeowner_team": "@googleapis/api-profiler"
+  "codeowner_team": "@googleapis/api-logging"
 }


### PR DESCRIPTION
Due to absense of the api-profiler team and the fact that the api-logging team is currently maintains issues for the repo
the api-logging team is added as code owners instead of api-profiler.

This change comes to unload yoshi-nodejs team from review tasks. 