### PR TITLE
test: reduce integration test flakiness

### DIFF
--- a/system-test/integration_test.go
+++ b/system-test/integration_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration && go1.7
 // +build integration,go1.7
 
 package e2e
@@ -96,7 +97,7 @@ git reset --hard {{.Commit}}
 
 retry npm_install --nodedir="$NODEDIR"
 
-npm run compile 
+npm run compile
 npm pack --nodedir="$NODEDIR" >/dev/null
 VERSION=$(node -e "console.log(require('./package.json').version);")
 PROFILER="$HOME/cloud-profiler-nodejs/google-cloud-profiler-$VERSION.tgz"
@@ -110,6 +111,9 @@ retry npm_install node-pre-gyp
 retry npm_install --nodedir="$NODEDIR" "$PROFILER" typescript gts
 
 npm run compile
+
+# Workaround to reduce flakiness connecting to the metadata server.
+export DETECT_GCP_RETRIES=5
 {{- end }}
 
 {{ define "integration" -}}

--- a/system-test/integration_test.go
+++ b/system-test/integration_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build integration && go1.7
-// +build integration,go1.7
 
 package e2e
 

--- a/system-test/integration_test.sh
+++ b/system-test/integration_test.sh
@@ -47,5 +47,7 @@ retry go1.17.7 test -c -tags=integration .
 if [ "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" = "" ]; then
   ./e2e.test -commit="$COMMIT" -branch="$BRANCH" -repo="$REPO" -run_backoff_test=true
 else
-  ./e2e.test -commit="$COMMIT" -pr="$KOKORO_GITHUB_PULL_REQUEST_NUMBER"
+  # The flag -run_backoff_test=true is only set so it's triggered in presubmit.
+  # Once presubmit passes, remove it and squash it when merging the PR.
+  ./e2e.test -commit="$COMMIT" -pr="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" -run_backoff_test=true
 fi

--- a/system-test/integration_test.sh
+++ b/system-test/integration_test.sh
@@ -47,5 +47,5 @@ retry go1.17.7 test -c -tags=integration .
 if [ "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" = "" ]; then
   ./e2e.test -commit="$COMMIT" -branch="$BRANCH" -repo="$REPO" -run_backoff_test=true
 else
-  ./e2e.test -commit="$COMMIT" -pr="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" -run_backoff_test=true
+  ./e2e.test -commit="$COMMIT" -pr="$KOKORO_GITHUB_PULL_REQUEST_NUMBER"
 fi

--- a/system-test/integration_test.sh
+++ b/system-test/integration_test.sh
@@ -47,7 +47,5 @@ retry go1.17.7 test -c -tags=integration .
 if [ "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" = "" ]; then
   ./e2e.test -commit="$COMMIT" -branch="$BRANCH" -repo="$REPO" -run_backoff_test=true
 else
-  # The flag -run_backoff_test=true is only set so it's triggered in presubmit.
-  # Once presubmit passes, remove it and squash it when merging the PR.
-  ./e2e.test -commit="$COMMIT" -pr="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" -run_backoff_test=true
+  ./e2e.test -commit="$COMMIT" -pr="$KOKORO_GITHUB_PULL_REQUEST_NUMBER"
 fi

--- a/system-test/integration_test.sh
+++ b/system-test/integration_test.sh
@@ -47,5 +47,5 @@ retry go1.17.7 test -c -tags=integration .
 if [ "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" = "" ]; then
   ./e2e.test -commit="$COMMIT" -branch="$BRANCH" -repo="$REPO" -run_backoff_test=true
 else
-  ./e2e.test -commit="$COMMIT" -pr="$KOKORO_GITHUB_PULL_REQUEST_NUMBER"
+  ./e2e.test -commit="$COMMIT" -pr="$KOKORO_GITHUB_PULL_REQUEST_NUMBER" -run_backoff_test=true
 fi


### PR DESCRIPTION
The test now retries when connecting to the metadata server.

Go 1.17 [build constraint](https://pkg.go.dev/go/build/constraint#pkg-overview) syntax was also added.

Tested by temporarily having presubmit also run the backoff tests.

The Golint check may fail because there is no .mod file. This is intentional and integration_test.sh does the module initialization.

Windows check may also fail but can be ignored ([Windows is not supported](https://cloud.google.com/profiler/docs/about-profiler#environment_and_languages)).