### PR TITLE
chore: remove windows check from workflow

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -38,5 +38,4 @@ branchProtectionRules:
     - "test (12)"
     - "test (14)"
     - "test (16)"
-    - "windows"
     - "system-test"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,17 +26,6 @@ jobs:
       - run: npm test
         env:
           MOCHA_THROW_DEPRECATION: false
-  windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - run: npm install
-      - run: npm test
-        env:
-          MOCHA_THROW_DEPRECATION: false
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,17 @@ jobs:
       - run: npm test
         env:
           MOCHA_THROW_DEPRECATION: false
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - run: npm install
+      - run: npm test
+        env:
+          MOCHA_THROW_DEPRECATION: false
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/owlbot.py
+++ b/owlbot.py
@@ -1,0 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import synthtool.languages.node as node
+
+node.owlbot_main(templates_excludes=[".github/sync-repo-settings.yaml"])


### PR DESCRIPTION
Cloud Profiler is [not supported](https://cloud.google.com/profiler/docs/about-profiler#environment_and_languages) in Windows. Removing the github check.