### PR TITLE
fix: initial module in golint presubmit check

### DIFF
--- a/.github/workflows/ci2.yaml
+++ b/.github/workflows/ci2.yaml
@@ -25,5 +25,18 @@ jobs:
     runs-on: ubuntu-latest
     container: golang:latest
     steps:
-      - run: gofmtdiff=$(gofmt -s -d .) && if [ -n "$gofmtdiff" ]; then printf 'gofmt -s found:\n%s\n' "$gofmtdiff" && exit 1; fi
-      - run: go get -u golang.org/x/lint/golint && golintlint=$($GOPATH/bin/golint ./...) && if [ -n "$golintlint" ]; then printf 'golint found:\n%s\n' "$golintlint" && exit 1; fi
+      - run: |
+          gofmtdiff=$(gofmt -s -d .)
+          if [ -n "$gofmtdiff" ]
+          then
+            printf 'gofmt -s found:\n%s\n' "$gofmtdiff" && exit 1;
+          fi
+      - run: |
+          go mod init tools
+          go get -u golang.org/x/lint/golint
+          go install golang.org/x/lint/golint
+          golintlint=$(golint ./...)
+          if [ -n "$golintlint" ]
+          then
+            printf 'golint found:\n%s\n' "$golintlint" && exit 1
+          fi


### PR DESCRIPTION
This change adds a call to `go mod init tools` before installing golint. This should failure observed in golint tests.