### PR TITLE
fix: relax service name requirements to allow starting with numbers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import {Profiler} from './profiler';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pjson = require('../../package.json');
-const serviceRegex = /^[a-z]([-a-z0-9_.]{0,253}[a-z0-9])?$/;
+const serviceRegex = /^[a-z0-9]([-a-z0-9_.]{0,253}[a-z0-9])?$/;
 
 function hasService(
   config: Config

--- a/test/test-init-config.ts
+++ b/test/test-init-config.ts
@@ -257,7 +257,7 @@ describe('createProfiler', () => {
     } catch (e) {
       assert.strictEqual(
         e.message,
-        'Service serviceName does not match regular expression "/^[a-z]([-a-z0-9_.]{0,253}[a-z0-9])?$/"'
+        'Service serviceName does not match regular expression "/^[a-z0-9]([-a-z0-9_.]{0,253}[a-z0-9])?$/"'
       );
     }
   });


### PR DESCRIPTION
With this change, profiling agents can be run with App Engine applications whose service names start with number.