### PR TITLE
test: add node 16 and remove windows from github workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,10 @@
+# This file is manually updated due to specific needs of the cloud
+# profiler agent, e.g., not supporting Windows.
+#
+# It should be in sync with Google's template
+# https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
+# for Node.js GCP libraries as much as possible.
+
 on:
   push:
     branches:
@@ -9,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14]
+        node: [10, 12, 14, 16]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -22,17 +29,6 @@ jobs:
       - run: npm install --production --engine-strict --ignore-scripts --no-package-lock
       # Clean up the production install, before installing dev/production:
       - run: rm -rf node_modules
-      - run: npm install
-      - run: npm test
-        env:
-          MOCHA_THROW_DEPRECATION: false
-  windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14
       - run: npm install
       - run: npm test
         env:

--- a/owlbot.py
+++ b/owlbot.py
@@ -14,4 +14,5 @@
 
 import synthtool.languages.node as node
 
-node.owlbot_main(templates_excludes=[".github/sync-repo-settings.yaml"])
+node.owlbot_main(templates_excludes=[".github/sync-repo-settings.yaml",
+                                     ".github/workflows/ci.yaml"])


### PR DESCRIPTION
Some PRs can't be merged because node 16 tests are missing from the github workflow. Also while windows tests are not required, they are still being run.

This PR adds node 16 and removes windows in ci.yaml. This helps unblock the yoshi-nodejs team, so they can help the api-profiler team merge dependency updates.

Removing node 10 is a breaking change, and should probably be done separately.