### PR TITLE
chore: do not specify @google-cloud/profiler in test package.json

### DIFF
--- a/system-test/busybench/package.json
+++ b/system-test/busybench/package.json
@@ -23,7 +23,5 @@
     "posttest": "npm run check"
   },
   "devDependencies": {},
-  "dependencies": {
-    "@google-cloud/profiler": "^4.2.0"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
The benchmark test should use the version of @google-cloud/profiler at head on GitHub; specifying the version within this package.json seems potentially misleading (though may not be causing issue). 
