### PR TITLE
fix: fix build so it includes expected files (and modify test to catch this)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
   "files": [
     "build/src",
     "build/third_party/cloud-debug-nodejs",
-    "bindings",
     "build/protos"
   ],
   "nyc": {

--- a/system-test/integration_test.go
+++ b/system-test/integration_test.go
@@ -99,6 +99,7 @@ retry npm_install --nodedir="$NODEDIR"
 npm run compile
 npm pack --nodedir="$NODEDIR" >/dev/null
 VERSION=$(node -e "console.log(require('./package.json').version);")
+PROFILER="$HOME/cloud-profiler-nodejs/google-cloud-profiler-$VERSION.tgz"
 
 TESTDIR="$HOME/test"
 mkdir -p "$TESTDIR"
@@ -106,7 +107,7 @@ cp -r "system-test/busybench" "$TESTDIR"
 cd "$TESTDIR/busybench"
 
 retry npm_install @mapbox/node-pre-gyp --save
-retry npm_install --nodedir="$NODEDIR" typescript gts; npm link ../../cloud-profiler-nodejs
+retry npm_install --nodedir="$NODEDIR" "$PROFILER" typescript gts
 
 npm run compile
 

--- a/test/test-init-config.ts
+++ b/test/test-init-config.ts
@@ -20,7 +20,7 @@ import * as sinon from 'sinon';
 
 import {createProfiler, nodeVersionOkay} from '../src/index';
 import {Profiler} from '../src/profiler';
-import * as packageJson from '../package.json';
+const packageJson = require('../../package.json');
 
 describe('nodeVersionOkay', () => {
   const version = parseInt(packageJson.engines.node.replace('>=', ''));


### PR DESCRIPTION
This change does the following:
* Remove "bindings" from the list of published files (this was left-over from when native portions of the agent were in this directory)
* Modify integration_test.go so it lightly tests the build pathway.
* Switch from `import * as packageJson from '../package.json';` to `const packageJson = require('../../package.json');`, which results in the build from `npm publish --dry-run` including ".js" files.


BEGIN_COMMIT_OVERRIDE
fix: fix build so it includes expected files (and modify test to catch this)
END_COMMIT_OVERRIDE