### PR TITLE
Revert "chore(deps): upgrade pprof to v3.2.1 [security]"

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
     "system-test": "c8 --no-clean mocha build/system-test/test-*.js --timeout=60000",
     "samples-test": "echo 'no sample tests'",
     "clean": "gts clean",
-    "compile": "tsc -p .",
+    "compile": "tsc -p . && cp -R protos build",
     "fix": "gts fix",
     "lint": "gts check",
     "docs": "jsdoc -c .jsdoc.js",
     "prelint": "cd samples; npm link ../; npm install",
     "prepare": "npm run compile",
     "pretest": "npm run compile",
+    "proto": "mkdir -p protos && pbjs -t static-module -w commonjs -o protos/profiler.js third_party/googleapis/google/devtools/cloudprofiler/v2/profiler.proto && pbts -o protos/profiler.d.ts protos/profiler.js",
     "license-check": "jsgl --local .",
     "docs-test": "linkinator docs",
     "predocs-test": "npm run docs",
@@ -36,9 +37,9 @@
     "extend": "^3.0.2",
     "gcp-metadata": "^4.0.0",
     "parse-duration": "^1.0.0",
-    "pprof": "3.2.1",
+    "pprof": "3.2.0",
     "pretty-ms": "^7.0.0",
-    "protobufjs": "~7.2.4",
+    "protobufjs": "~7.2.0",
     "semver": "^7.0.0",
     "teeny-request": "^8.0.0"
   },
@@ -68,10 +69,12 @@
   },
   "files": [
     "build/src",
-    "build/third_party/cloud-debug-nodejs"
+    "build/third_party/cloud-debug-nodejs",
+    "build/protos"
   ],
   "nyc": {
     "exclude": [
+      "protos",
       "build/test",
       "build/system-test"
     ]

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -20,12 +20,12 @@ import {
   DecorateRequestOptions,
 } from '@google-cloud/common';
 import {heap as heapProfiler, SourceMapper, time as timeProfiler} from 'pprof';
-import {perftools} from 'pprof/proto/profile';
 import * as msToStr from 'pretty-ms';
 import {promisify} from 'util';
 import * as zlib from 'zlib';
 import * as r from 'teeny-request';
 
+import {perftools} from '../protos/profile';
 import {ProfilerConfig} from './config';
 import {createLogger} from './logger';
 

--- a/system-test/test-start.ts
+++ b/system-test/test-start.ts
@@ -19,7 +19,7 @@ import * as nock from 'nock';
 import {promisify} from 'util';
 import * as zlib from 'zlib';
 
-import {perftools} from 'pprof/proto/profile';
+import {perftools} from '../protos/profile';
 import {RequestProfile} from '../src/profiler';
 
 const API = 'https://cloudprofiler.googleapis.com/v2';

--- a/test/profiles-for-tests.ts
+++ b/test/profiles-for-tests.ts
@@ -17,7 +17,7 @@ import * as path from 'path';
 import {SourceMapGenerator} from 'source-map';
 import * as tmp from 'tmp';
 
-import {perftools} from 'pprof/proto/profile';
+import {perftools} from '../protos/profile';
 import {TimeProfile} from '../src/v8-types';
 
 const timeLeaf1 = {

--- a/test/test-profiler.ts
+++ b/test/test-profiler.ts
@@ -26,7 +26,7 @@ import * as sinon from 'sinon';
 import {promisify} from 'util';
 import * as zlib from 'zlib';
 
-import {perftools} from 'pprof/proto/profile';
+import {perftools} from '../protos/profile';
 import {ProfilerConfig} from '../src/config';
 import {
   parseBackoffDuration,


### PR DESCRIPTION
Reverts googleapis/cloud-profiler-nodejs#883

1. The actual commit ended up with the wrong version number
2. release-please won't release this, [it needs `deps: ...` format](https://github.com/googleapis/release-please#releasable-units).

I will recreate the PR with correct commit message and try again.