### PR TITLE
fix(deps): upgrade pprof to v3.2.1 [security]

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,13 @@
     "system-test": "c8 --no-clean mocha build/system-test/test-*.js --timeout=60000",
     "samples-test": "echo 'no sample tests'",
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -R protos build",
+    "compile": "tsc -p .",
     "fix": "gts fix",
     "lint": "gts check",
     "docs": "jsdoc -c .jsdoc.js",
     "prelint": "cd samples; npm link ../; npm install",
     "prepare": "npm run compile",
     "pretest": "npm run compile",
-    "proto": "mkdir -p protos && pbjs -t static-module -w commonjs -o protos/profiler.js third_party/googleapis/google/devtools/cloudprofiler/v2/profiler.proto && pbts -o protos/profiler.d.ts protos/profiler.js",
     "license-check": "jsgl --local .",
     "docs-test": "linkinator docs",
     "predocs-test": "npm run docs",
@@ -37,9 +36,9 @@
     "extend": "^3.0.2",
     "gcp-metadata": "^4.0.0",
     "parse-duration": "^1.0.0",
-    "pprof": "3.2.0",
+    "pprof": "3.2.1",
     "pretty-ms": "^7.0.0",
-    "protobufjs": "~7.2.0",
+    "protobufjs": "~7.2.4",
     "semver": "^7.0.0",
     "teeny-request": "^8.0.0"
   },
@@ -69,12 +68,10 @@
   },
   "files": [
     "build/src",
-    "build/third_party/cloud-debug-nodejs",
-    "build/protos"
+    "build/third_party/cloud-debug-nodejs"
   ],
   "nyc": {
     "exclude": [
-      "protos",
       "build/test",
       "build/system-test"
     ]

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -20,12 +20,12 @@ import {
   DecorateRequestOptions,
 } from '@google-cloud/common';
 import {heap as heapProfiler, SourceMapper, time as timeProfiler} from 'pprof';
+import {perftools} from 'pprof/proto/profile';
 import * as msToStr from 'pretty-ms';
 import {promisify} from 'util';
 import * as zlib from 'zlib';
 import * as r from 'teeny-request';
 
-import {perftools} from '../protos/profile';
 import {ProfilerConfig} from './config';
 import {createLogger} from './logger';
 

--- a/system-test/test-start.ts
+++ b/system-test/test-start.ts
@@ -19,7 +19,7 @@ import * as nock from 'nock';
 import {promisify} from 'util';
 import * as zlib from 'zlib';
 
-import {perftools} from '../protos/profile';
+import {perftools} from 'pprof/proto/profile';
 import {RequestProfile} from '../src/profiler';
 
 const API = 'https://cloudprofiler.googleapis.com/v2';

--- a/test/profiles-for-tests.ts
+++ b/test/profiles-for-tests.ts
@@ -17,7 +17,7 @@ import * as path from 'path';
 import {SourceMapGenerator} from 'source-map';
 import * as tmp from 'tmp';
 
-import {perftools} from '../protos/profile';
+import {perftools} from 'pprof/proto/profile';
 import {TimeProfile} from '../src/v8-types';
 
 const timeLeaf1 = {

--- a/test/test-profiler.ts
+++ b/test/test-profiler.ts
@@ -26,7 +26,7 @@ import * as sinon from 'sinon';
 import {promisify} from 'util';
 import * as zlib from 'zlib';
 
-import {perftools} from '../protos/profile';
+import {perftools} from 'pprof/proto/profile';
 import {ProfilerConfig} from '../src/config';
 import {
   parseBackoffDuration,


### PR DESCRIPTION
Fixes https://github.com/googleapis/cloud-profiler-nodejs/issues/879, take two of https://github.com/googleapis/cloud-profiler-nodejs/pull/883 with correct commit message (was reverted in #884).

This caused an issue where the proto definitions in `protos/` are incompatible with those returned from pprof. The fix I assumed was to regenerate the protos with `npm run protos`, however this fails because the third_party directory was removed in https://github.com/googleapis/cloud-profiler-nodejs/pull/486.

To make things work, I instead just imported the same proto definitions from pprof library. I will delete the now unused `protos/` directory for the next major version release as someone could theoretically have been importing them from build, just to be safe.
