### PR TITLE
deps: fix CI by setting @google-cloud/promisify version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@google-cloud/common": "^5.0.0",
     "@google-cloud/logging-min": "^11.0.0",
+    "@google-cloud/promisify": "~4.0.0",
     "@types/console-log-level": "^1.4.0",
     "@types/semver": "^7.0.0",
     "console-log-level": "^1.4.0",


### PR DESCRIPTION
Since that is the newest version that support Node 14. See https://github.com/googleapis/cloud-profiler-nodejs/actions/runs/14347851446/job/40220930459?pr=960 for an example CI failure.