### PR TITLE
test: add test for behavior with invalid duration returned

### DIFF
--- a/test/test-profiler.ts
+++ b/test/test-profiler.ts
@@ -734,8 +734,12 @@ describe('Profiler', () => {
       | undefined
       | sinon.SinonStub<[DecorateRequestOptions, BodyResponseCallback], void>;
     let randomStub: sinon.SinonStub<[], number> | undefined;
+
+    const RANDOM_VALUE = 0.5;
+    // Retryer calculates expected backoff as RANDOM_VALUE * testConfig.initialBackoffMillis => 0.5 * 1000
+    const EXPECTED_BACKOFF = 500;
     before(() => {
-      randomStub = sinon.stub(Math, 'random').returns(0.5);
+      randomStub = sinon.stub(Math, 'random').returns(RANDOM_VALUE);
     });
     afterEach(() => {
       if (requestStub) {
@@ -782,7 +786,7 @@ describe('Profiler', () => {
 
         const profiler = new Profiler(testConfig);
         const delayMillis = await profiler.collectProfile();
-        assert.deepStrictEqual(500, delayMillis);
+        assert.deepStrictEqual(EXPECTED_BACKOFF, delayMillis);
       }
     );
     it('should reset backoff after success', async () => {
@@ -868,7 +872,7 @@ describe('Profiler', () => {
           );
         const profiler = new Profiler(testConfig);
         const delayMillis = await profiler.collectProfile();
-        assert.strictEqual(500, delayMillis);
+        assert.strictEqual(EXPECTED_BACKOFF, delayMillis);
       }
     );
     it(
@@ -886,7 +890,7 @@ describe('Profiler', () => {
           );
         const profiler = new Profiler(testConfig);
         const delayMillis = await profiler.collectProfile();
-        assert.strictEqual(500, delayMillis);
+        assert.strictEqual(EXPECTED_BACKOFF, delayMillis);
       }
     );
     it(

--- a/test/test-profiler.ts
+++ b/test/test-profiler.ts
@@ -872,6 +872,24 @@ describe('Profiler', () => {
       }
     );
     it(
+      'should return expected backoff when non-200 error and invalid server backoff' +
+        ' string specified',
+      async () => {
+        requestStub = sinon
+          .stub(common.ServiceObject.prototype, 'request')
+          .onCall(0)
+          .callsArgWith(
+            1,
+            undefined,
+            {error: {details: [{retryDelay: 'not a duration'}]}},
+            {statusCode: 409}
+          );
+        const profiler = new Profiler(testConfig);
+        const delayMillis = await profiler.collectProfile();
+        assert.strictEqual(500, delayMillis);
+      }
+    );
+    it(
       'should return backoff limit, when server specified backoff is greater' +
         ' then backoff limit',
       async () => {


### PR DESCRIPTION
Follow up to https://github.com/googleapis/cloud-profiler-nodejs/pull/960. I verified this test behavior is the same before and after https://github.com/googleapis/cloud-profiler-nodejs/pull/960